### PR TITLE
Added booter support, NullBooter and NetBooter

### DIFF
--- a/localboot/bootconfig.go
+++ b/localboot/bootconfig.go
@@ -17,10 +17,13 @@ type BootConfig struct {
 	Cmdline    string
 }
 
+// IsValid returns true if the BootConfig has a valid kernel and initrd entry
 func (bc BootConfig) IsValid() bool {
 	return bc.Kernel != nil && bc.Initrd != nil
 }
 
+// Boot tries to boot the kernel pointed by the BootConfig option, or returns an
+// error if it cannot be booted. The kernel is loaded using kexec
 func (bc BootConfig) Boot() error {
 	if err := kexec.FileLoad(bc.Kernel, bc.Initrd, bc.Cmdline); err != nil {
 		return err
@@ -30,6 +33,7 @@ func (bc BootConfig) Boot() error {
 	return nil
 }
 
+// Close will close all the open file descriptor used for kernel and initrd
 func (bc *BootConfig) Close() {
 	if bc.Kernel != nil {
 		bc.Kernel.Close()

--- a/localboot/filesystem.go
+++ b/localboot/filesystem.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 )
 
+// Mountpoint holds mount point information for a given device
 type Mountpoint struct {
 	DeviceName string
 	Path       string

--- a/localboot/grub.go
+++ b/localboot/grub.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 )
 
+// List of paths where to look for grub config files. Grub2Paths will look for
+// files with grub2-compatible syntax, GrubLegacyPaths similarly will treat
+// these as grub-legacy config files.
 var (
 	Grub2Paths = []string{
 		// grub2

--- a/pkg/booter/bootentry.go
+++ b/pkg/booter/bootentry.go
@@ -26,11 +26,11 @@ func GetBooterFor(entry BootEntry) Booter {
 		booter Booter
 		err    error
 	)
-	for _, booterParser := range supportedBooterParsers {
-		log.Printf("Trying booter: %+v", booterParser)
+	for idx, booterParser := range supportedBooterParsers {
+		log.Printf("Trying booter #%d", idx)
 		booter, err = booterParser(entry.Config)
 		if err != nil {
-			log.Printf("This config is not valid for booter %+v", booterParser)
+			log.Printf("This config is not valid for this booter (#%d)", idx)
 			continue
 		}
 		break

--- a/pkg/booter/bootentry.go
+++ b/pkg/booter/bootentry.go
@@ -7,6 +7,8 @@ import (
 	"github.com/insomniacslk/systemboot/pkg/vpd"
 )
 
+// BootEntry represents a boot entry, with its name, configuration, and Booter
+// instance. It can map to existing key-value stores like VPD or EFI vars.
 type BootEntry struct {
 	Name   string
 	Config []byte
@@ -40,6 +42,8 @@ func GetBooterFor(entry BootEntry) Booter {
 	return booter
 }
 
+// GetBootEntries returns a list of BootEntry objecsts stored in the VPD
+// partition of the flash chip
 func GetBootEntries() []BootEntry {
 	var bootEntries []BootEntry
 	for idx := 0; idx < 9999; idx++ {

--- a/pkg/booter/bootentry.go
+++ b/pkg/booter/bootentry.go
@@ -7,6 +7,14 @@ import (
 	"github.com/insomniacslk/systemboot/pkg/vpd"
 )
 
+// Get, Set and GetAll are defined here as variables so they can be overridden
+// for testing, or for using a key-value store other than VPD.
+var (
+	Get    = vpd.Get
+	Set    = vpd.Set
+	GetAll = vpd.GetAll
+)
+
 // BootEntry represents a boot entry, with its name, configuration, and Booter
 // instance. It can map to existing key-value stores like VPD or EFI vars.
 type BootEntry struct {
@@ -42,14 +50,14 @@ func GetBooterFor(entry BootEntry) Booter {
 	return booter
 }
 
-// GetBootEntries returns a list of BootEntry objecsts stored in the VPD
+// GetBootEntries returns a list of BootEntry objects stored in the VPD
 // partition of the flash chip
 func GetBootEntries() []BootEntry {
 	var bootEntries []BootEntry
 	for idx := 0; idx < 9999; idx++ {
 		key := fmt.Sprintf("Boot%04d", idx)
 		// try the RW entries first
-		value, err := vpd.Get(key, false)
+		value, err := Get(key, false)
 		if err == nil {
 			bootEntries = append(bootEntries, BootEntry{Name: key, Config: value})
 			// WARNING WARNING WARNING this means that read-write boot entries
@@ -57,7 +65,7 @@ func GetBootEntries() []BootEntry {
 			continue
 		}
 		// try the RO entries then
-		value, err = vpd.Get(key, true)
+		value, err = Get(key, true)
 		if err == nil {
 			bootEntries = append(bootEntries, BootEntry{Name: key, Config: value})
 		}

--- a/pkg/booter/bootentry.go
+++ b/pkg/booter/bootentry.go
@@ -1,0 +1,70 @@
+package booter
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/insomniacslk/systemboot/pkg/vpd"
+)
+
+type BootEntry struct {
+	Name   string
+	Config []byte
+	Booter Booter
+}
+
+var supportedBooterParsers = []func([]byte) (Booter, error){
+	NewNetBooter,
+}
+
+// GetBooterFor looks for a supported Booter implementation and returns it, if
+// found. If not found, a NullBooter is returned.
+func GetBooterFor(entry BootEntry) Booter {
+	var (
+		booter Booter
+		err    error
+	)
+	for _, booterParser := range supportedBooterParsers {
+		log.Printf("Trying booter: %+v", booterParser)
+		booter, err = booterParser(entry.Config)
+		if err != nil {
+			log.Printf("This config is not valid for booter %+v", booterParser)
+			continue
+		}
+		break
+	}
+	if booter == nil {
+		log.Printf("No booter found for entry: %+v", entry)
+		return &NullBooter{}
+	}
+	return booter
+}
+
+func GetBootEntries() []BootEntry {
+	var bootEntries []BootEntry
+	for idx := 0; idx < 9999; idx++ {
+		key := fmt.Sprintf("Boot%04d", idx)
+		// try the RW entries first
+		value, err := vpd.Get(key, false)
+		if err == nil {
+			bootEntries = append(bootEntries, BootEntry{Name: key, Config: value})
+			// WARNING WARNING WARNING this means that read-write boot entries
+			// have priority over read-only ones
+			continue
+		}
+		// try the RO entries then
+		value, err = vpd.Get(key, true)
+		if err == nil {
+			bootEntries = append(bootEntries, BootEntry{Name: key, Config: value})
+		}
+	}
+	// look for a Booter that supports the given configuration
+	for idx, entry := range bootEntries {
+		entry.Booter = GetBooterFor(entry)
+		if entry.Booter == nil {
+			log.Printf("No booter found for entry: %+v", entry)
+		}
+		bootEntries[idx] = entry
+	}
+	return bootEntries
+}

--- a/pkg/booter/bootentry_test.go
+++ b/pkg/booter/bootentry_test.go
@@ -1,0 +1,82 @@
+package booter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBooterForNetBooter(t *testing.T) {
+	validConfig := BootEntry{
+		Name:   "Boot0000",
+		Config: []byte(`{"type": "netboot", "method": "dhcpv6", "mac": "aa:bb:cc:dd:ee:ff"}`),
+	}
+	booter := GetBooterFor(validConfig)
+	require.NotNil(t, booter)
+	require.Equal(t, booter.TypeName(), "netboot")
+	require.NotNil(t, booter.(*NetBooter))
+}
+
+func TestGetBooterForNullBooter(t *testing.T) {
+	validConfig := BootEntry{
+		Name:   "Boot0000",
+		Config: []byte(`{"type": "null"}`),
+	}
+	booter := GetBooterFor(validConfig)
+	require.NotNil(t, booter)
+	require.Equal(t, booter.TypeName(), "null")
+	require.NotNil(t, booter.(*NullBooter))
+	require.Nil(t, booter.Boot())
+}
+
+func TestGetBooterForInvalidBooter(t *testing.T) {
+	invalidConfig := BootEntry{
+		Name:   "Boot0000",
+		Config: []byte(`{"type": "invalid"`),
+	}
+	booter := GetBooterFor(invalidConfig)
+	require.NotNil(t, booter)
+	// an invalid config returns always a NullBooter
+	require.Equal(t, booter.TypeName(), "null")
+	require.NotNil(t, booter.(*NullBooter))
+	require.Nil(t, booter.Boot())
+}
+
+func TestGetBootEntries(t *testing.T) {
+	var (
+		bootConfig0000 = []byte(`{"type": "netboot", "method": "dhcpv6", "mac": "aa:bb:cc:dd:ee:ff"}`)
+		bootConfig0001 = []byte(`{"type": "localboot", "uuid": "blah-bleh", "kernel": "/path/to/kernel"}`)
+	)
+	// Override the package-level variable Get so it will use our dummy getter
+	// instead of VPD
+	Get = func(key string, readOnly bool) ([]byte, error) {
+		switch key {
+		case "Boot0000":
+			return bootConfig0000, nil
+		case "Boot0001":
+			return bootConfig0001, nil
+		default:
+			return nil, errors.New("No such key")
+		}
+	}
+	entries := GetBootEntries()
+	require.Equal(t, len(entries), 2)
+	require.Equal(t, "Boot0000", entries[0].Name)
+	require.Equal(t, bootConfig0000, entries[0].Config)
+	require.Equal(t, "Boot0001", entries[1].Name)
+	require.Equal(t, bootConfig0001, entries[1].Config)
+}
+
+func TestGetBootEntriesOnlyRO(t *testing.T) {
+	// Override the package-level variable Get so it will use our dummy getter
+	// instead of VPD
+	Get = func(key string, readOnly bool) ([]byte, error) {
+		if !readOnly || key != "Boot0000" {
+			return nil, errors.New("No such key")
+		}
+		return []byte(`{"type": "netboot", "method": "dhcpv6", "mac": "aa:bb:cc:dd:ee:ff"}`), nil
+	}
+	entries := GetBootEntries()
+	require.Equal(t, len(entries), 1)
+}

--- a/pkg/booter/booter.go
+++ b/pkg/booter/booter.go
@@ -14,10 +14,13 @@ type Booter interface {
 type NullBooter struct {
 }
 
+// TypeName returns the name of the booter type
 func (nb *NullBooter) TypeName() string {
 	return "null"
 }
 
+// Boot will run the boot procedure. In the case of this NullBooter it will do
+// nothing
 func (nb *NullBooter) Boot() error {
 	log.Printf("Null booter does nothing")
 	return nil

--- a/pkg/booter/booter.go
+++ b/pkg/booter/booter.go
@@ -1,0 +1,24 @@
+package booter
+
+import "log"
+
+// Booter is an interface that defines custom boot types. Implementations can be
+// like network boot, local boot, etc.
+type Booter interface {
+	Boot() error
+	TypeName() string
+}
+
+// NullBooter is a dummy booter that does nothing. It is used when no other
+// booter has been found
+type NullBooter struct {
+}
+
+func (nb *NullBooter) TypeName() string {
+	return "null"
+}
+
+func (nb *NullBooter) Boot() error {
+	log.Printf("Null booter does nothing")
+	return nil
+}

--- a/pkg/booter/netbooter.go
+++ b/pkg/booter/netbooter.go
@@ -1,0 +1,77 @@
+package booter
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+)
+
+// NetBooter implements the Booter interface for booting over DHCPv6.
+// See NewNetBooterDHCPv6 for details on the fields.
+type NetBooter struct {
+	Type        string `json:"type"`
+	Method      string `json:"method"`
+	MAC         string `json:"mac"`
+	OverrideURL string `json:"override_url,omitempty"`
+}
+
+func NewNetBooter(config []byte) (Booter, error) {
+	// The configuration format for a NetBooterDHCPv6 entry is a JSON with the
+	// following structure:
+	// {
+	//     "type": "netboot",
+	//     "method": "<method>",
+	//     "mac": "<mac_addr>",
+	//     "override_url": "<url>"
+	// }
+	//
+	// `type` is always set to "netboot".
+	// `method` is one of "dhcpv6", "slaac" or "dhcpv4".
+	// `mac` is the MAC address of the interface to use to boot.
+	// `override_url` is an optional URL used to override the boot file URL used
+	//   to fetch the network boot program. This field becomes mandatory if
+	//   `method` is set to "slaac".
+	//
+	// An example configuration is:
+	// {
+	//     "type": "netboot",
+	//     "method": "dhcpv6",
+	//     "mac": "aa:bb:cc:dd:ee:ff",
+	//     "override_url": "http://[fe80::face:booc]:8080/path/to/boot/file"
+	// }
+	//
+	// Note that the optional `override_url` in the example above will override
+	// whatever URL is returned in the OPT_BOOTFILE_URL for DHCPv6, or TFTP server
+	// name + bootfile URL in case of DHCPv4.
+	//
+	// Additional options may be added in the future.
+	log.Printf("Trying NetBooter...")
+	log.Printf("Config: %s", string(config))
+	nb := NetBooter{}
+	if err := json.Unmarshal(config, &nb); err != nil {
+		return nil, err
+	}
+	log.Printf("NetBooter: %+v", nb)
+	if nb.Type != "netboot" {
+		return nil, fmt.Errorf("Wrong type for NetBooter: %s", nb.Type)
+	}
+	return &nb, nil
+}
+
+func (nb *NetBooter) Boot() error {
+	bootcmd := []string{"netboot", "-d", "-userclass", "linuxboot"}
+	log.Printf("Executing command: %v", bootcmd)
+	cmd := exec.Command(bootcmd[0], bootcmd[1:]...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Printf("Error executing %v: %v", cmd, err)
+	}
+	// This should be never reached
+	return nil
+}
+
+func (nb *NetBooter) TypeName() string {
+	return nb.Type
+}

--- a/pkg/booter/netbooter.go
+++ b/pkg/booter/netbooter.go
@@ -17,6 +17,8 @@ type NetBooter struct {
 	OverrideURL string `json:"override_url,omitempty"`
 }
 
+// NewNetBooter parses a boot entry config and returns a Booter instance, or an
+// error if any
 func NewNetBooter(config []byte) (Booter, error) {
 	// The configuration format for a NetBooterDHCPv6 entry is a JSON with the
 	// following structure:
@@ -60,6 +62,8 @@ func NewNetBooter(config []byte) (Booter, error) {
 	return &nb, nil
 }
 
+// Boot will run the boot procedure. In the case of NetBooter, it will call the
+// `netboot` command
 func (nb *NetBooter) Boot() error {
 	bootcmd := []string{"netboot", "-d", "-userclass", "linuxboot"}
 	log.Printf("Executing command: %v", bootcmd)
@@ -72,6 +76,7 @@ func (nb *NetBooter) Boot() error {
 	return nil
 }
 
+// TypeName returns the name of the booter type
 func (nb *NetBooter) TypeName() string {
 	return nb.Type
 }

--- a/uinit/main.go
+++ b/uinit/main.go
@@ -20,10 +20,6 @@ var defaultBootsequence = [][]string{
 	[]string{"localboot"},
 }
 
-var supportedBooterParsers = []func([]byte) (booter.Booter, error){
-	booter.NewNetBooter,
-}
-
 func main() {
 	flag.Parse()
 

--- a/uinit/main.go
+++ b/uinit/main.go
@@ -5,37 +5,45 @@ import (
 	"log"
 	"os/exec"
 	"time"
-)
 
-// TODO allow to specify boot sequence
+	"github.com/insomniacslk/systemboot/pkg/booter"
+)
 
 var (
-	doQuiet  = flag.Bool("q", false, "Disable verbose output")
-	interval = flag.Int("I", 1, "Interval in seconds before looping to the next boot command")
+	doQuiet       = flag.Bool("q", false, "Disable verbose output")
+	interval      = flag.Int("I", 1, "Interval in seconds before looping to the next boot command")
+	noDefaultBoot = flag.Bool("nodefault", false, "Do not attempt default boot entries if regular ones fail")
 )
 
-var bootsequence = [][]string{
+var defaultBootsequence = [][]string{
 	[]string{"netboot", "-userclass", "linuxboot"},
 	[]string{"localboot"},
+}
+
+var supportedBooterParsers = []func([]byte) (booter.Booter, error){
+	booter.NewNetBooter,
 }
 
 func main() {
 	flag.Parse()
 
+	log.Printf("*************************************************************************")
 	log.Print("Starting boot sequence, press CTRL-C within 5 seconds to drop into a shell")
+	log.Printf("*************************************************************************")
 	time.Sleep(5 * time.Second)
 
 	sleepInterval := time.Duration(*interval) * time.Second
-	for {
-		for _, bootcmd := range bootsequence {
-			if !*doQuiet {
-				bootcmd = append(bootcmd, "-d")
-			}
-			log.Printf("Running boot command: %v", bootcmd)
-			cmd := exec.Command(bootcmd[0], bootcmd[1:]...)
-			if err := cmd.Run(); err != nil {
-				log.Printf("Error executing %v: %v", cmd, err)
-			}
+
+	// Get and show boot entries
+	bootEntries := booter.GetBootEntries()
+	log.Printf("BOOT ENTRIES:")
+	for _, entry := range bootEntries {
+		log.Printf("    %v) %+v", entry.Name, string(entry.Config))
+	}
+	for _, entry := range bootEntries {
+		log.Printf("Trying boot entry %s: %s", entry.Name, string(entry.Config))
+		if err := entry.Booter.Boot(); err != nil {
+			log.Printf("Warning: failed to boot with configuration: %+v", entry)
 		}
 		if !*doQuiet {
 			log.Printf("Sleeping %v before attempting next boot command", sleepInterval)
@@ -43,4 +51,26 @@ func main() {
 		time.Sleep(sleepInterval)
 	}
 
+	// if boot entries failed, use the default boot sequence
+	log.Printf("Boot entries failed")
+
+	if !*noDefaultBoot {
+		log.Print("Falling back to the default boot sequence")
+		for {
+			for _, bootcmd := range defaultBootsequence {
+				if !*doQuiet {
+					bootcmd = append(bootcmd, "-d")
+				}
+				log.Printf("Running boot command: %v", bootcmd)
+				cmd := exec.Command(bootcmd[0], bootcmd[1:]...)
+				if err := cmd.Run(); err != nil {
+					log.Printf("Error executing %v: %v", cmd, err)
+				}
+			}
+			if !*doQuiet {
+				log.Printf("Sleeping %v before attempting next boot command", sleepInterval)
+			}
+			time.Sleep(sleepInterval)
+		}
+	}
 }


### PR DESCRIPTION
Added pkg/booter and updated uinit to use it.

`pkg/booter` defines a Booter interface that allows the creation of booting logic, e.g. network booting, local booting, and specific configuration.
A `NullBooter` and a `NetBooter` object have been included.

The booters follow a specification based on JSON, and the current implementation stores the content on VPD variables, but any key-value store can be used.