### PR TITLE
Added BootConfig definition

### DIFF
--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -1,0 +1,21 @@
+package bootconfig
+
+import "encoding/json"
+
+// BootConfig is a general-purpose boot configuration. It draws some
+// characteristics from FIT but it's not compatible with it. It uses
+// JSON for interoperability.
+type BootConfig struct {
+	Name       string `json:"name"`
+	Kernel     string `json:"kernel"`
+	Initramfs  string `json:"initramfs"`
+	KernelArgs string `json:"kernel_args"`
+}
+
+func NewBootConfig(data []byte) (*BootConfig, error) {
+	var bootconfig BootConfig
+	if err := json.Unmarshal(data, &bootconfig); err != nil {
+		return nil, err
+	}
+	return &bootconfig, nil
+}

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -10,7 +10,7 @@ type BootConfig struct {
 	Kernel     string `json:"kernel"`
 	Initramfs  string `json:"initramfs,omitempty"`
 	KernelArgs string `json:"kernel_args,omitempty"`
-	DeviceTree string `json:"devicetree"`
+	DeviceTree string `json:"devicetree,omitempty"`
 }
 
 func NewBootConfig(data []byte) (*BootConfig, error) {

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -8,8 +8,9 @@ import "encoding/json"
 type BootConfig struct {
 	Name       string `json:"name"`
 	Kernel     string `json:"kernel"`
-	Initramfs  string `json:"initramfs"`
-	KernelArgs string `json:"kernel_args"`
+	Initramfs  string `json:"initramfs,omitempty"`
+	KernelArgs string `json:"kernel_args,omitempty"`
+	DeviceTree string `json:"devicetree"`
 }
 
 func NewBootConfig(data []byte) (*BootConfig, error) {


### PR DESCRIPTION
This is the first step to build @zaolin's BootConfig at https://github.com/systemboot/systemboot/pull/37 .
This is the base for more flexible booters that are inspired to FIT but with a simpler syntax and a standard parser (BootConfig uses JSON, FIT uses a custom format that requires a custom parser).