### PR TITLE
Added ManifestConfig

### DIFF
--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -13,6 +13,8 @@ type BootConfig struct {
 	DeviceTree string `json:"devicetree,omitempty"`
 }
 
+// NewBootConfig parses a boot configuration in JSON format and returns a
+// BootConfig object.
 func NewBootConfig(data []byte) (*BootConfig, error) {
 	var bootconfig BootConfig
 	if err := json.Unmarshal(data, &bootconfig); err != nil {

--- a/pkg/bootconfig/manifest.go
+++ b/pkg/bootconfig/manifest.go
@@ -1,0 +1,19 @@
+package bootconfig
+
+import "encoding/json"
+
+// ManifestConfig is a list of BootConfig objects. The goal is to provide
+// multiple configurations to choose from.
+type ManifestConfig struct {
+	Configs []BootConfig `json:"configs"`
+}
+
+// NewManifestConfig parses a manifest configuration, i.e. a list of boot
+// configurations, in JSON format and returns a ManifestConfig object.
+func NewManifestConfig(data []byte) (*ManifestConfig, error) {
+	var manifestConfig ManifestConfig
+	if err := json.Unmarshal(data, &manifestConfig); err != nil {
+		return nil, err
+	}
+	return &manifestConfig, nil
+}


### PR DESCRIPTION
ManifestConfig wraps a list of BootConfig objects. This will map the actual content of the boot configuration in JSON format