### PR TITLE
Support blockdev stats for kernel 4.18+

### DIFF
--- a/pkg/storage/blockdev.go
+++ b/pkg/storage/blockdev.go
@@ -96,7 +96,7 @@ func BlockStatFromBytes(buf []byte) (*BlockStat, error) {
 	fields := strings.Fields(string(buf))
 	// BlockStat has 11 fields
 	if len(fields) < 11 {
-		return nil, fmt.Errorf("BlockStatFromBytes: parsing %q: got %d fields(%q), want 11", buf, len(fields), fields)
+		return nil, fmt.Errorf("BlockStatFromBytes: parsing %q: got %d fields(%q), want at least 11", buf, len(fields), fields)
 	}
 	intfields := make([]uint64, 0)
 	for _, field := range fields {

--- a/pkg/storage/blockdev.go
+++ b/pkg/storage/blockdev.go
@@ -71,6 +71,12 @@ type BlockStat struct {
 	InFlight     uint64
 	IOTicks      uint64
 	TimeInQueue  uint64
+	// Kernel 4.18 added four fields for discard tracking, see
+	// https://github.com/torvalds/linux/commit/bdca3c87fb7ad1cc61d231d37eb0d8f90d001e0c
+	DiscardIOs     uint64
+	DiscardMerges  uint64
+	DiscardSectors uint64
+	DiscardTicks   uint64
 }
 
 // SystemPartitionGUID is the GUID of EFI system partitions
@@ -89,7 +95,7 @@ var SystemPartitionGUID = gpt.Guid([...]byte{
 func BlockStatFromBytes(buf []byte) (*BlockStat, error) {
 	fields := strings.Fields(string(buf))
 	// BlockStat has 11 fields
-	if len(fields) != 11 {
+	if len(fields) < 11 {
 		return nil, fmt.Errorf("BlockStatFromBytes: parsing %q: got %d fields(%q), want 11", buf, len(fields), fields)
 	}
 	intfields := make([]uint64, 0)
@@ -100,7 +106,7 @@ func BlockStatFromBytes(buf []byte) (*BlockStat, error) {
 		}
 		intfields = append(intfields, v)
 	}
-	return &BlockStat{
+	bs := BlockStat{
 		ReadIOs:      intfields[0],
 		ReadMerges:   intfields[1],
 		ReadSectors:  intfields[2],
@@ -112,7 +118,14 @@ func BlockStatFromBytes(buf []byte) (*BlockStat, error) {
 		InFlight:     intfields[8],
 		IOTicks:      intfields[9],
 		TimeInQueue:  intfields[10],
-	}, nil
+	}
+	if len(fields) >= 15 {
+		bs.DiscardIOs = intfields[11]
+		bs.DiscardMerges = intfields[12]
+		bs.DiscardSectors = intfields[13]
+		bs.DiscardTicks = intfields[14]
+	}
+	return &bs, nil
 }
 
 // GetBlockStats iterates over /sys/class/block entries and returns a list of

--- a/pkg/storage/blockdev_test.go
+++ b/pkg/storage/blockdev_test.go
@@ -22,3 +22,28 @@ func TestFindMountPointValid(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, *mountpoint, "/media/usb")
 }
+
+func TestBlockStatFromBytes15Fields(t *testing.T) {
+    // dummy values, don't judge me
+    input := []byte("       0        1        2        3        4        5        6        7        8        9        10        11        12        13        14\n")
+    bs, err := BlockStatFromBytes(input)
+    require.NoError(t, err)
+    require.Equal(t, uint64(5), bs.WriteMerges)
+    require.Equal(t, uint64(14), bs.DiscardTicks)
+}
+
+func TestBlockStatFromBytes11Fields(t *testing.T) {
+    // dummy values, don't judge me
+    input := []byte("       0        1        2        3        4        5        6        7        8        9        10\n")
+    bs, err := BlockStatFromBytes(input)
+    require.NoError(t, err)
+    require.Equal(t, uint64(5), bs.WriteMerges)
+    require.Equal(t, uint64(0), bs.DiscardTicks)
+}
+
+func TestBlockStatFromBytesNotEnoughFields(t *testing.T) {
+    // dummy values, don't judge me
+    input := []byte("       0        1        2        3        4        5        6        7        8\n")
+    _, err := BlockStatFromBytes(input)
+    require.Error(t, err)
+}


### PR DESCRIPTION
Kernels 4.18+ have a different format for /sys/class/block/<device>/stat, four new fields appeared in https://github.com/torvalds/linux/commit/bdca3c87fb7ad1cc61d231d37eb0d8f90d001e0c . This patch addresses it, and relaxes the checks to look for at least 11 fields, not exactly 11 (or 15).

Thanks @rminnich for reporting it