### PR TITLE
Require Go 1.11 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The `uinit` program just wraps `netboot` and `localboot` in a forever-loop logic
 
 ## How to build systemboot
 
-* Install a recent version of Go, we recommend 1.10 or later
+* Install Go 1.11
 * make sure that your PATH points appropriately to wherever Go stores the
   go-get'ed executables
 * Then build it with the `u-root` ramfs builder using the following commands:


### PR DESCRIPTION
The README for u-root says "Make sure your Go version is 1.11." The first step of the build process is to install github.com/u-root/u-root. Therefore, systemboot requires 1.11, not 1.10 or later