### PR TITLE
Update to reflect dhcp new Exchange interface

### DIFF
--- a/netboot/main.go
+++ b/netboot/main.go
@@ -179,7 +179,7 @@ func main() {
 			log.Print("DHCPv4: sending request")
 			client := dhcpv4.NewClient()
 			// TODO add options to request to netboot
-			conversation, err := client.Exchange(*ifname, nil)
+			conversation, err := client.Exchange(*ifname)
 			for _, m := range conversation {
 				debug(m.Summary())
 			}


### PR DESCRIPTION
In https://github.com/insomniacslk/dhcp/pull/181 the Exchange interface was modified. This patch updates the code to reflect it.

Without this patch, the netboot program will crash when doing DHCPv4