### PR TITLE
uinit: Don't lose debug output in default cmds

### DIFF
--- a/uinit/main.go
+++ b/uinit/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
 	"os/exec"
 	"time"
 
@@ -67,6 +68,8 @@ func main() {
 				}
 				log.Printf("Running boot command: %v", bootcmd)
 				cmd := exec.Command(bootcmd[0], bootcmd[1:]...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
 				if err := cmd.Run(); err != nil {
 					log.Printf("Error executing %v: %v", cmd, err)
 				}


### PR DESCRIPTION
The quiet flag is used to decide between running the subcommands with
`-d` or not, but it doesn't make a difference since the output is
captured and discarded.

In the spirit of uinit being a "script", redirect the output of the
commands to stdout and stderr. This is done both when quiet and when
not, since the `-d` flag passed to the boot commands is already used to
increase or decrease verbosity