### PR TITLE
Bootconfig fixes/improvements

### DIFF
--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"os/exec"
 
 	"github.com/systemboot/systemboot/pkg/crypto"
 	"github.com/u-root/u-root/pkg/kexec"
@@ -31,17 +32,21 @@ func (bc *BootConfig) IsValid() bool {
 // Boot tries to boot the kernel with optional initramfs and command line
 // options. If a device-tree is specified, that will be used too
 func (bc *BootConfig) Boot() error {
-	// kexec: try the kexecbin executable first, and if it fails, use the native
-	// Go implementation of kexec from u-root
-	log.Printf("Trying KexecBin on %+v", bc)
 	crypto.TryMeasureBootConfig(bc.Name, bc.Kernel, bc.Initramfs, bc.KernelArgs, bc.DeviceTree)
+
+	// kexec: try the kexecbin executable first
+	// if it is not available fallback to the Go implementation of kexec from u-root
+	log.Printf("Trying KexecBin on %+v", bc)
 	if err := kexecbin.KexecBin(bc.Kernel, bc.KernelArgs, bc.Initramfs, bc.DeviceTree); err != nil {
-		if os.IsNotExist(err) {
-			log.Printf("BootConfig: KexecBin failed, trying pure-Go kexec. Error: %v", err)
+		// If it was found nowhere in PATH it will be exec.Error{exec.ErrNotFound}, which we have to unpack
+		execErr, ok := err.(*exec.Error)
+		if (ok && execErr.Err == exec.ErrNotFound) || os.IsNotExist(err) {
+			log.Printf("BootConfig: KexecBin is not available, trying pure-Go kexec. Error: %v", err)
 		} else {
 			return err
 		}
 	}
+
 	kernel, err := os.Open(bc.Kernel)
 	if err != nil {
 		return err

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -65,7 +65,10 @@ func (bc *BootConfig) Boot() error {
 			}
 		}
 	}()
-	return kexec.FileLoad(kernel, initramfs, bc.KernelArgs)
+	if err := kexec.FileLoad(kernel, initramfs, bc.KernelArgs); err != nil {
+		return err
+	}
+	return kexec.Reboot()
 }
 
 // NewBootConfig parses a boot configuration in JSON format and returns a

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -2,6 +2,7 @@ package bootconfig
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"os"
 
@@ -68,7 +69,13 @@ func (bc *BootConfig) Boot() error {
 	if err := kexec.FileLoad(kernel, initramfs, bc.KernelArgs); err != nil {
 		return err
 	}
-	return kexec.Reboot()
+
+	err = kexec.Reboot()
+	if err == nil {
+		return errors.New("Unexpectedly returned from Reboot() without error. The system did not reboot")
+	}
+	return err
+
 }
 
 // NewBootConfig parses a boot configuration in JSON format and returns a


### PR DESCRIPTION
PR #65 refactored the bootconfig implementation, and in the process made it so we only load the kexec kernel, but don't boot it. This will be bundled with the fix for #77 since this code is unreachable because of that at the moment anyway