### PR TITLE
pkg/bootconfig: refactored, and added NewManifest

### DIFF
--- a/pkg/bootconfig/manifest.go
+++ b/pkg/bootconfig/manifest.go
@@ -5,19 +5,32 @@ import (
 	"fmt"
 )
 
+// global variables
+var (
+	CurrentManifestVersion = 1
+)
+
 // Manifest is a list of BootConfig objects. The goal is to provide  multiple
 // configurations to choose from.
 type Manifest struct {
 	// Version is a positive integer that determines the version of the Manifest
 	// structure. This will be used when introducing breaking changes in the
-	// Manifest interface
+	// Manifest interface.
 	Version int          `json:"version"`
 	Configs []BootConfig `json:"configs"`
 }
 
-// NewManifest parses a manifest configuration, i.e. a list of boot
+// NewManifest returns a new empty Manifest structure with the current version
+// field populated.
+func NewManifest() *Manifest {
+	return &Manifest{
+		Version: CurrentManifestVersion,
+	}
+}
+
+// ManifestFromBytes parses a manifest configuration, i.e. a list of boot
 // configurations, in JSON format and returns a Manifest object.
-func NewManifest(data []byte) (*Manifest, error) {
+func ManifestFromBytes(data []byte) (*Manifest, error) {
 	var manifest Manifest
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, err
@@ -25,6 +38,8 @@ func NewManifest(data []byte) (*Manifest, error) {
 	return &manifest, nil
 }
 
+// GetBootConfig returns the i-th boot configuration from the manifest, or an
+// error if an invalid index is passed.
 func (mc *Manifest) GetBootConfig(idx int) (*BootConfig, error) {
 	if idx < 0 || idx >= len(mc.Configs) {
 		return nil, fmt.Errorf("Invalid index: not in range: %d", idx)

--- a/pkg/bootconfig/manifest_test.go
+++ b/pkg/bootconfig/manifest_test.go
@@ -8,6 +8,12 @@ import (
 )
 
 func TestNewManifest(t *testing.T) {
+	m := NewManifest()
+	require.NotNil(t, m)
+	require.Equal(t, m.Version, CurrentManifestVersion)
+}
+
+func TestManifestFromBytes(t *testing.T) {
 	data := []byte(`{
 	"version": 1,
 	"configs": [
@@ -20,19 +26,19 @@ func TestNewManifest(t *testing.T) {
 		}
 	]
 }`)
-	m, err := NewManifest(data)
+	m, err := ManifestFromBytes(data)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(m.Configs))
 }
 
-func TestNewManifestInvalid(t *testing.T) {
+func TestManifestFromBytesInvalid(t *testing.T) {
 	data := []byte(`{
 		"nonexisting": "baaah",
 		"configs": {
 			"broken": true
 		}
 }`)
-	_, err := NewManifest(data)
+	_, err := ManifestFromBytes(data)
 	require.Error(t, err)
 }
 
@@ -46,7 +52,7 @@ func TestManifestGetBootConfig(t *testing.T) {
 		}
 	]
 }`)
-	m, err := NewManifest(data)
+	m, err := ManifestFromBytes(data)
 	require.NoError(t, err)
 	config, err := m.GetBootConfig(0)
 	require.NoError(t, err)
@@ -64,7 +70,7 @@ func TestManifestGetBootConfigMissing(t *testing.T) {
 		}
 	]
 }`)
-	m, err := NewManifest(data)
+	m, err := ManifestFromBytes(data)
 	require.NoError(t, err)
 	_, err = m.GetBootConfig(1)
 	require.Error(t, err)

--- a/pkg/bootconfig/zipconfig.go
+++ b/pkg/bootconfig/zipconfig.go
@@ -121,7 +121,7 @@ func FromZip(filename string, pubkeyfile *string) (*Manifest, string, error) {
 					log.Printf("Warning: duplicate manifest.json found, the last found wins")
 				}
 				// parse the Manifest containing the boot configurations
-				manifest, err = NewManifest(buf)
+				manifest, err = ManifestFromBytes(buf)
 				if err != nil {
 					return nil, "", err
 				}


### PR DESCRIPTION
The old `NewManifest` function was a misnomer, it's a parser. Also added a proper `NewManifest` function, plus tests.