### PR TITLE
Drop support for Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 sudo: false
 
 go:
-  - "1.10"
   - "1.11"
 
 before_install:


### PR DESCRIPTION
Drop support for Go 1.10. Systemboot is based on u-root, that is only tested on Go 1.11. It makes no sense for us to support more versions, and this is also causing some failures, e.g. in https://github.com/systemboot/systemboot/pull/91 (works on 1.11, fails on 1.10 because of an u-root dependency)