### PR TITLE
localboot: added newlines where missing

### DIFF
--- a/localboot/main.go
+++ b/localboot/main.go
@@ -211,9 +211,9 @@ func main() {
 			}
 			log.Printf("  Table: %+v", table)
 			for _, part := range table.Partitions {
-				log.Printf("    Partition: %+v", part)
+				log.Printf("    Partition: %+v\n", part)
 				if !part.IsEmpty() {
-					log.Printf("      UUID: %s", part.Type.String())
+					log.Printf("      UUID: %s\n", part.Type.String())
 				}
 			}
 		}


### PR DESCRIPTION
I noticed that the output of localboot is missing newlines where necessary, and a VERY long line was printed instead of a more readable set of lines. This patch fixes it.