### PR TITLE
Add vpdbootmanager utility to manage boot entries

### DIFF
--- a/cmds/vpdbootmanager/add.go
+++ b/cmds/vpdbootmanager/add.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/systemboot/systemboot/pkg/booter"
+	"github.com/systemboot/systemboot/pkg/vpd"
+)
+
+var dryRun = false
+
+func add(entrytype string, args []string) error {
+	var entry booter.Booter
+	var err error
+	switch entrytype {
+	case "netboot":
+		if len(args) < 2 {
+			return fmt.Errorf("You need to pass method and MAC address")
+		}
+		entry, err = parseNetbootFlags(args[0], args[1], args[2:])
+		if err != nil {
+			return err
+		}
+	case "localboot":
+		if len(args) < 1 {
+			return fmt.Errorf("You need to provide method")
+		}
+		entry, err = parseLocalbootFlags(args[0], args[1:])
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("Unknown entry type")
+	}
+	if dryRun {
+		b, err := json.Marshal(entry)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stderr, "Using -dryrun, will not write any variable. Content of boot entry:")
+		fmt.Println(string(b))
+		return nil
+	}
+	return addBootEntry(entry)
+}
+
+func parseLocalbootFlags(method string, args []string) (*booter.LocalBooter, error) {
+	cfg := &booter.LocalBooter{
+		Type:   "localboot",
+		Method: method,
+	}
+	flg := flag.NewFlagSet("localboot", flag.ExitOnError)
+	flg.StringVar(&cfg.KernelArgs, "kernel-args", "", "additional kernel args")
+	flg.StringVar(&cfg.Initramfs, "ramfs", "", "path of ramfs to be used for kexec'ing into the target kernel.")
+	flg.StringVar(&vpd.VpdDir, "vpd-dir", vpd.VpdDir, "VPD dir to use")
+	flg.BoolVar(&dryRun, "dryrun", false, "only print values that would be set")
+
+	switch method {
+	case "grub":
+		flg.Parse(args)
+	case "path":
+		if len(args) < 2 {
+			return nil, fmt.Errorf("You need to pass DeviceGUID and Kernel path")
+		}
+		cfg.DeviceGUID = args[0]
+		cfg.Kernel = args[1]
+		flg.Parse(args[2:])
+	default:
+		return nil, fmt.Errorf("Method needs to be grub or path")
+	}
+	return cfg, nil
+}
+
+func parseNetbootFlags(method, mac string, args []string) (*booter.NetBooter, error) {
+	if method != "dhcpv4" && method != "dhcpv6" {
+		return nil, fmt.Errorf("Method needs to be either dhcpv4 or dhcpv6")
+	}
+
+	_, err := net.ParseMAC(mac)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &booter.NetBooter{
+		Type:   "netboot",
+		Method: method,
+		MAC:    mac,
+	}
+
+	flg := flag.NewFlagSet("netboot", flag.ExitOnError)
+	overrideURL := flg.String("override-url", "", "an optional URL used to override the boot file URL used")
+	retries := flg.Int("retries", -1, "the number of times a DHCP request should be retried if failed.")
+	flg.BoolVar(&dryRun, "dryrun", false, "only print values that would be set")
+	flg.StringVar(&vpd.VpdDir, "vpd-dir", vpd.VpdDir, "VPD dir to use")
+	flg.Parse(args)
+
+	if *overrideURL != "" {
+		cfg.OverrideURL = overrideURL
+	}
+
+	if *retries != -1 {
+		cfg.Retries = retries
+	}
+
+	return cfg, nil
+}
+
+func addBootEntry(cfg booter.Booter) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	for i := 1; i < vpd.MaxBootEntry; i++ {
+		key := fmt.Sprintf("Boot%04d", i)
+		if _, err := vpd.Get(key, false); err != nil {
+			if os.IsNotExist(err) {
+				if err := vpd.Set(key, data, false); err != nil {
+					return err
+				}
+				return nil
+			}
+			return err
+		}
+	}
+	return errors.New("Maximum number of boot entries already set")
+}

--- a/cmds/vpdbootmanager/add_test.go
+++ b/cmds/vpdbootmanager/add_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/systemboot/systemboot/pkg/booter"
+
+	"github.com/systemboot/systemboot/pkg/vpd"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNetboot(t *testing.T) {
+	b, err := parseNetbootFlags("dhcpv4", "aa:bb:cc:dd:ee:ff", []string{})
+	require.NoError(t, err)
+	require.Equal(t, "netboot", b.Type)
+	require.Equal(t, "dhcpv4", b.Method)
+	require.Equal(t, "aa:bb:cc:dd:ee:ff", b.MAC)
+	require.Nil(t, b.OverrideURL)
+	require.Nil(t, b.Retries)
+}
+
+func TestParseNetbootWithFlags(t *testing.T) {
+	b, err := parseNetbootFlags("dhcpv4", "aa:bb:cc:dd:ee:ff", []string{
+		"-override-url",
+		"http://url",
+		"-retries",
+		"1",
+		"-vpd-dir",
+		"test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "http://url", *b.OverrideURL)
+	require.Equal(t, 1, *b.Retries)
+	require.Equal(t, "test", vpd.VpdDir)
+}
+
+func TestParseLocalboot(t *testing.T) {
+	b, err := parseLocalbootFlags("grub", []string{})
+	require.NoError(t, err)
+	require.Equal(t, "grub", b.Method)
+
+	b, err = parseLocalbootFlags("path", []string{
+		"device",
+		"path",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "path", b.Method)
+	require.Equal(t, "device", b.DeviceGUID)
+	require.Equal(t, "path", b.Kernel)
+}
+
+func TestParseLocalbootWithFlags(t *testing.T) {
+	b, err := parseLocalbootFlags("grub", []string{
+		"-kernel-args",
+		"kernel-argument-test",
+		"-ramfs",
+		"ramfs-test",
+		"-vpd-dir",
+		"test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "grub", b.Method)
+	require.Equal(t, "kernel-argument-test", b.KernelArgs)
+	require.Equal(t, "ramfs-test", b.Initramfs)
+	require.Equal(t, "test", vpd.VpdDir)
+
+	b, err = parseLocalbootFlags("path", []string{
+		"device",
+		"path",
+		"-kernel-args",
+		"kernel-argument-test",
+		"-ramfs",
+		"ramfs-test",
+		"-vpd-dir",
+		"test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "path", b.Method)
+	require.Equal(t, "device", b.DeviceGUID)
+	require.Equal(t, "path", b.Kernel)
+	require.Equal(t, "kernel-argument-test", b.KernelArgs)
+	require.Equal(t, "ramfs-test", b.Initramfs)
+	require.Equal(t, "test", vpd.VpdDir)
+}
+
+func TestFailGracefullyMissingArg(t *testing.T) {
+	err := add("localboot", []string{})
+	require.Equal(t, "You need to provide method", err.Error())
+
+	err = add("localboot", []string{"path"})
+	require.Equal(t, "You need to pass DeviceGUID and Kernel path", err.Error())
+
+	err = add("localboot", []string{"path", "device"})
+	require.Equal(t, "You need to pass DeviceGUID and Kernel path", err.Error())
+
+	err = add("netboot", []string{})
+	require.Equal(t, "You need to pass method and MAC address", err.Error())
+
+	err = add("netboot", []string{"dhcpv6"})
+	require.Equal(t, "You need to pass method and MAC address", err.Error())
+}
+
+func TestFailGracefullyBadMACAddress(t *testing.T) {
+	err := add("netboot", []string{"dhcpv6", "test"})
+	require.Equal(t, "address test: invalid MAC address", err.Error())
+}
+
+func TestFailGracefullyBadNetworkType(t *testing.T) {
+	err := add("netboot", []string{"not-valid", "test"})
+	require.Equal(t, "Method needs to be either dhcpv4 or dhcpv6", err.Error())
+}
+
+func TestFailGracefullyBadLocalbootType(t *testing.T) {
+	err := add("localboot", []string{"not-valid"})
+	require.Equal(t, "Method needs to be grub or path", err.Error())
+}
+
+func TestFailGracefullyUnknownEntryType(t *testing.T) {
+	err := add("test", []string{})
+	require.Equal(t, "Unknown entry type", err.Error())
+}
+
+func TestAddBootEntry(t *testing.T) {
+	dir, err := ioutil.TempDir("", "vpdbootmanager")
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.MkdirAll(path.Join(dir, "rw"), 0700)
+	defer os.RemoveAll(dir)
+	vpd.VpdDir = dir
+	err = addBootEntry(&booter.LocalBooter{
+		Method: "grub",
+	})
+	require.NoError(t, err)
+	file, err := ioutil.ReadFile(path.Join(dir, "rw", "Boot0001"))
+	require.NoError(t, err)
+	var out booter.LocalBooter
+	err = json.Unmarshal([]byte(file), &out)
+	require.NoError(t, err)
+	require.Equal(t, "grub", out.Method)
+}
+
+func TestAddBootEntryMultiple(t *testing.T) {
+	dir, err := ioutil.TempDir("", "vpdbootmanager")
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.MkdirAll(path.Join(dir, "rw"), 0700)
+	defer os.RemoveAll(dir)
+	vpd.VpdDir = dir
+	for i := 1; i < 5; i++ {
+		err = addBootEntry(&booter.LocalBooter{
+			Method: "grub",
+		})
+		require.NoError(t, err)
+		file, err := ioutil.ReadFile(path.Join(dir, "rw", fmt.Sprintf("Boot%04d", i)))
+		require.NoError(t, err)
+		var out booter.LocalBooter
+		err = json.Unmarshal([]byte(file), &out)
+		require.NoError(t, err)
+		require.Equal(t, "grub", out.Method)
+	}
+}

--- a/cmds/vpdbootmanager/main.go
+++ b/cmds/vpdbootmanager/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const usage = `Usage:
+%s add [netboot [dhcpv6|dhcpv4] [MAC] | localboot [grub|path [Device GUID] [Kernel Path]]]
+
+Ex.
+add localboot grub
+add netboot dhcpv6 AA:BB:CC:DD:EE:FF
+
+Flags for netboot:
+
+-override-url - an optional URL used to override the boot file URL used
+-retries - the number of times a DHCP request should be retried if failed
+
+Flags for localboot:
+
+-kernel-args - additional kernel args
+-ramfs - path of ramfs to be used for kexec'ing into the target kernel
+
+Global flags:
+
+-vpd-dir - VPD dir to use
+
+`
+
+func main() {
+	if err := cli(os.Args[1:]); err != nil {
+		fmt.Printf(usage, os.Args[0])
+		fmt.Printf("Error: %s\n\n", err)
+		os.Exit(1)
+	}
+}
+
+func cli(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("You need to provide action")
+	}
+	switch args[0] {
+	case "add":
+		return add(args[1], args[2:])
+	}
+	return fmt.Errorf("Unrecognized action")
+}

--- a/cmds/vpdbootmanager/main_test.go
+++ b/cmds/vpdbootmanager/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/systemboot/systemboot/pkg/booter"
+)
+
+func TestInvalidCommand(t *testing.T) {
+	err := cli([]string{"unknown"})
+	require.Equal(t, "Unrecognized action", err.Error())
+}
+
+func TestNoEntryType(t *testing.T) {
+	err := cli([]string{"add", "localboot"})
+	require.Equal(t, "You need to provide method", err.Error())
+}
+
+func TestNoAction(t *testing.T) {
+	err := cli([]string{})
+	require.Equal(t, "You need to provide action", err.Error())
+}
+
+func TestAddNetbootEntryFull(t *testing.T) {
+	dir, err := ioutil.TempDir("", "vpdbootmanager")
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.MkdirAll(path.Join(dir, "rw"), 0700)
+	defer os.RemoveAll(dir)
+	err = cli([]string{
+		"add",
+		"netboot",
+		"dhcpv6",
+		"aa:bb:cc:dd:ee:ff",
+		"-vpd-dir",
+		dir,
+	})
+	require.NoError(t, err)
+	file, err := ioutil.ReadFile(path.Join(dir, "rw", "Boot0001"))
+	require.NoError(t, err)
+	var out booter.NetBooter
+	err = json.Unmarshal([]byte(file), &out)
+	require.NoError(t, err)
+	require.Equal(t, "dhcpv6", out.Method)
+	require.Equal(t, "aa:bb:cc:dd:ee:ff", out.MAC)
+}
+
+func TestAddLocalbootEntryFull(t *testing.T) {
+	dir, err := ioutil.TempDir("", "vpdbootmanager")
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.MkdirAll(path.Join(dir, "rw"), 0700)
+	defer os.RemoveAll(dir)
+	err = cli([]string{
+		"add",
+		"localboot",
+		"grub",
+		"-vpd-dir",
+		dir,
+	})
+	require.NoError(t, err)
+	file, err := ioutil.ReadFile(path.Join(dir, "rw", "Boot0001"))
+	require.NoError(t, err)
+	var out booter.NetBooter
+	err = json.Unmarshal([]byte(file), &out)
+	require.NoError(t, err)
+	require.Equal(t, "grub", out.Method)
+}

--- a/pkg/vpd/vpd.go
+++ b/pkg/vpd/vpd.go
@@ -10,7 +10,8 @@ import (
 // VpdDir points to the base directory where the VPD sysfs interface is located.
 // It is an exported variable to allow for testing
 var (
-	VpdDir = "/sys/firmware/vpd"
+	VpdDir       = "/sys/firmware/vpd"
+	MaxBootEntry = 9999
 )
 
 func getBaseDir(readOnly bool) string {


### PR DESCRIPTION
This will add a simple CLI util to manage boot entries. 

**Add netboot entry ex**

```
~/go/src/github.com/systemboot/systemboot/util/vpd $ mkdir test/ro
~/go/src/github.com/systemboot/systemboot/util/vpd $ go run main.go boot --vpd-dir test add netboot dhcpv6 AA:BB:CC:DD:EE:FF
INFO[0000] Successfylly added boot entry.
~/go/src/github.com/systemboot/systemboot/util/vpd $ ls test/ro/
Boot0001
~/go/src/github.com/systemboot/systemboot/util/vpd $ cat test/ro/Boot0001
{"type":"netboot","method":"dhcpv6","mac":"AA:BB:CC:DD:EE:FF","retries":0}
```

**Add localboot entry ex**

```
~/go/src/github.com/systemboot/systemboot/util/vpd $ go run main.go boot --vpd-dir test add localboot path 1234 fake_kernel_file
INFO[0000] Successfylly added boot entry.
~/go/src/github.com/systemboot/systemboot/util/vpd $ ls test/ro/
Boot0001	Boot0002	Boot0003
~/go/src/github.com/systemboot/systemboot/util/vpd $ cat test/ro/Boot0003
{"type":"localboot","method":"path","device_guid":"1234","kernel":"fake_kernel_file"}
```

**Extra**

```
~/go/src/github.com/systemboot/systemboot/util/vpd $ go run main.go boot --vpd-dir test list
INFO[0000] Boot entries found:
INFO[0000] 	Boot0001
INFO[0000] 	Boot0002
INFO[0000] 	Boot0003
~/go/src/github.com/systemboot/systemboot/util/vpd $ go run main.go boot --vpd-dir test remove Boot0001
INFO[0000] Removed boot entry!
~/go/src/github.com/systemboot/systemboot/util/vpd $ go run main.go boot --vpd-dir test remove Boot0002
INFO[0000] Removed boot entry!
~/go/src/github.com/systemboot/systemboot/util/vpd $ go run main.go boot --vpd-dir test remove Boot0003
INFO[0000] Removed boot entry!
~/go/src/github.com/systemboot/systemboot/util/vpd $ ls test/ro/
~/go/src/github.com/systemboot/systemboot/util/vpd $
```

Note: --vpd-dir is used to override the default dir when testing, the default value when unspecified is that which is specified in `pkg/vpd`. 

int ref T41421367