### PR TITLE
localboot: add config flag to select bootconfig

### DIFF
--- a/localboot/main.go
+++ b/localboot/main.go
@@ -19,6 +19,7 @@ var (
 	flagBaseMountPoint = flag.String("m", "/mnt", "Base mount point where to mount partitions")
 	flagDryRun         = flag.Bool("dryrun", false, "Do not actually kexec into the boot config")
 	flagDebug          = flag.Bool("d", false, "Print debug output")
+	flagConfigIdx      = flag.Int("config", -1, "Specify the index of the configuration to boot. The order is determined by the menu entries in the Grub config")
 	flagGrubMode       = flag.Bool("grub", false, "Use GRUB mode, i.e. look for valid Grub/Grub2 configuration in default locations to boot a kernel. GRUB mode ignores -kernel/-initramfs/-cmdline")
 	flagKernelPath     = flag.String("kernel", "", "Specify the path of the kernel to execute. If using -grub, this argument is ignored")
 	flagInitramfsPath  = flag.String("initramfs", "", "Specify the path of the initramfs to load. If using -grub, this argument is ignored")
@@ -72,7 +73,7 @@ func mountByGUID(devices []storage.BlockDev, filesystems []string, guid, baseMou
 // instead.
 // The fourth parameter, `dryrun`, will not boot the found configurations if set
 // to true.
-func BootGrubMode(devices []storage.BlockDev, baseMountpoint string, guid string, dryrun bool) error {
+func BootGrubMode(devices []storage.BlockDev, baseMountpoint string, guid string, dryrun bool, configIdx int) error {
 	// get a list of supported file systems for real devices (i.e. skip nodev)
 	debug("Getting list of supported filesystems")
 	filesystems, err := storage.GetSupportedFilesystems()
@@ -116,14 +117,32 @@ func BootGrubMode(devices []storage.BlockDev, baseMountpoint string, guid string
 	for _, mountpoint := range mounted {
 		bootconfigs = append(bootconfigs, ScanGrubConfigs(mountpoint.Path)...)
 	}
+	if len(bootconfigs) == 0 {
+		return fmt.Errorf("No boot configuration found")
+	}
 	log.Printf("Found %d boot configs", len(bootconfigs))
 	for _, cfg := range bootconfigs {
 		debug("%+v", cfg)
 	}
-	if len(bootconfigs) == 0 {
-		return fmt.Errorf("No boot configuration found")
+	for n, cfg := range bootconfigs {
+		log.Printf("  %d: %s\n", n, cfg.Name)
 	}
-
+	if configIdx > -1 {
+		for n, cfg := range bootconfigs {
+			if configIdx == n {
+				if dryrun {
+					debug("Dry-run mode: will not boot the found configuration")
+					debug("Boot configuration: %+v", cfg)
+					return nil
+				}
+				if err := cfg.Boot(); err != nil {
+					log.Printf("Failed to boot kernel %s: %v", cfg.Kernel, err)
+				}
+			}
+		}
+		log.Printf("Invalid arg -config %d: there are only %d bootconfigs available\n", configIdx, len(bootconfigs))
+		return nil
+	}
 	if dryrun {
 		cfg := bootconfigs[0]
 		debug("Dry-run mode: will not boot the found configuration")
@@ -222,7 +241,7 @@ func main() {
 	// TODO boot from EFI system partitions. See storage.FilterEFISystemPartitions
 
 	if *flagGrubMode {
-		if err := BootGrubMode(devices, *flagBaseMountPoint, *flagDeviceGUID, *flagDryRun); err != nil {
+		if err := BootGrubMode(devices, *flagBaseMountPoint, *flagDeviceGUID, *flagDryRun, *flagConfigIdx); err != nil {
 			log.Fatal(err)
 		}
 	} else if *flagKernelPath != "" {


### PR DESCRIPTION
A little feature that comes in handy mainly for debugging.
You can do ```localboot -grub -dryrun``` which prints you the found bootconfigs at the end:
![pic](https://user-images.githubusercontent.com/14163031/54686862-8b4fb380-4b1a-11e9-849c-815c3a654f97.png)
Then you can run ```localboot -config 1``` to use the corresponding bootconfig.

