### PR TITLE
Efi integration

### DIFF
--- a/localboot/grub.go
+++ b/localboot/grub.go
@@ -3,43 +3,54 @@ package main
 import (
 	"io/ioutil"
 	"log"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/systemboot/systemboot/pkg/bootconfig"
 	"github.com/systemboot/systemboot/pkg/crypto"
 )
 
-// List of paths where to look for grub config files. Grub2Paths will look for
-// files with grub2-compatible syntax, GrubLegacyPaths similarly will treat
-// these as grub-legacy config files.
+// List of directories where to look for grub config files. The root dorectory
+// of each mountpoint, these folders inside the mountpoint and all subfolders
+// of these folders are searched
 var (
-	Grub2Paths = []string{
-		// grub2
-		"boot/grub2/grub.cfg",
-		"boot/grub2.cfg",
-		"grub2/grub.cfg",
-		"grub2.cfg",
-	}
-	GrubLegacyPaths = []string{
-		// grub legacy
-		"boot/grub/grub.cfg",
-		"boot/grub.cfg",
-		"grub/grub.cfg",
-		"grub.cfg",
+	GrubSearchDirectories = []string{
+		"boot",
+		"EFI",
+		"efi",
+		"grub",
+		"grub2",
 	}
 )
+
+type grubVersion int
+
+var (
+	grubV1 grubVersion = 1
+	grubV2 grubVersion = 2
+)
+
+func isGrubSearchDir(dirname string) bool {
+	for _, dir := range GrubSearchDirectories {
+		if dirname == dir {
+			return true
+		}
+	}
+	return false
+}
 
 // ParseGrubCfg parses the content of a grub.cfg and returns a list of
 // BootConfig structures, one for each menuentry, in the same order as they
 // appear in grub.cfg. All opened kernel and initrd files are relative to
 // basedir.
-func ParseGrubCfg(grubcfg string, basedir string, grubVersion int) []bootconfig.BootConfig {
+func ParseGrubCfg(ver grubVersion, grubcfg string, basedir string) []bootconfig.BootConfig {
 	// This parser sucks. It's not even a parser, it just looks for lines
 	// starting with menuentry, linux or initrd.
 	// TODO use a parser, e.g. https://github.com/alecthomas/participle
-	if grubVersion != 1 && grubVersion != 2 {
-		log.Printf("Warning: invalid GRUB version: %d", grubVersion)
+	if ver != grubV1 && ver != grubV2 {
+		log.Printf("Warning: invalid GRUB version: %d", ver)
 		return nil
 	}
 	bootconfigs := make([]bootconfig.BootConfig, 0)
@@ -65,6 +76,9 @@ func ParseGrubCfg(grubcfg string, basedir string, grubVersion int) []bootconfig.
 			}
 			inMenuEntry = true
 			cfg = new(bootconfig.BootConfig)
+			name := strings.Join(sline[1:], " ")
+			name = strings.Split(name, "--")[0]
+			cfg.Name = name
 		} else if inMenuEntry {
 			// otherwise look for kernel and initramfs configuration
 			if len(sline) < 2 {
@@ -74,17 +88,32 @@ func ParseGrubCfg(grubcfg string, basedir string, grubVersion int) []bootconfig.
 			if sline[0] == "linux" || sline[0] == "linux16" || sline[0] == "linuxefi" {
 				kernel := sline[1]
 				cmdline := strings.Join(sline[2:], " ")
-				if grubVersion == 2 {
-					// if grub2, unquote the string, as directives could be quoted
-					// https://www.gnu.org/software/grub/manual/grub/grub.html#Quoting
-					// TODO unquote everything, not just \$
-					cmdline = strings.Replace(cmdline, `\$`, "$", -1)
-				}
+				cmdline = unquote(ver, cmdline)
 				cfg.Kernel = path.Join(basedir, kernel)
 				cfg.KernelArgs = cmdline
 			} else if sline[0] == "initrd" || sline[0] == "initrd16" || sline[0] == "initrdefi" {
 				initrd := sline[1]
 				cfg.Initramfs = path.Join(basedir, initrd)
+			} else if sline[0] == "multiboot" || sline[0] == "multiboot2" {
+				multiboot := sline[1]
+				cmdline := strings.Join(sline[2:], " ")
+				cmdline = unquote(ver, cmdline)
+				cfg.Multiboot = path.Join(basedir, multiboot)
+				cfg.MultibootArgs = cmdline
+			} else if sline[0] == "module" || sline[0] == "module2" {
+				module := sline[1]
+				cmdline := strings.Join(sline[2:], " ")
+				if ver == grubV2 {
+					// if grub2, unquote the string, as directives could be quoted
+					// https://www.gnu.org/software/grub/manual/grub/grub.html#Quoting
+					// TODO unquote everything, not just \$
+					cmdline = strings.Replace(cmdline, `\$`, "$", -1)
+				}
+				module = path.Join(basedir, module)
+				if cmdline != "" {
+					module = module + " " + cmdline
+				}
+				cfg.Modules = append(cfg.Modules, module)
 			}
 		}
 	}
@@ -95,35 +124,53 @@ func ParseGrubCfg(grubcfg string, basedir string, grubVersion int) []bootconfig.
 	return bootconfigs
 }
 
+func unquote(ver grubVersion, text string) string {
+	if ver == grubV2 {
+		// if grub2, unquote the string, as directives could be quoted
+		// https://www.gnu.org/software/grub/manual/grub/grub.html#Quoting
+		// TODO unquote everything, not just \$
+		return strings.Replace(text, `\$`, "$", -1)
+	}
+	// otherwise return the unmodified string
+	return text
+}
+
 // ScanGrubConfigs looks for grub2 and grub legacy config files in the known
 // locations and returns a list of boot configurations.
 func ScanGrubConfigs(basedir string) []bootconfig.BootConfig {
 	bootconfigs := make([]bootconfig.BootConfig, 0)
-	// Scan Grub 2 configurations
-	for _, grubpath := range Grub2Paths {
-		path := path.Join(basedir, grubpath)
-		log.Printf("Trying to read %s", path)
-		grubcfg, err := ioutil.ReadFile(path)
-		if err != nil {
-			log.Printf("cannot open %s: %v", path, err)
-			continue
+	err := filepath.Walk(basedir, func(currentPath string, info os.FileInfo, err error) error {
+		if path.Dir(currentPath) == basedir && info.IsDir() && !isGrubSearchDir(path.Base(currentPath)) {
+			log.Printf("Skip %s", currentPath)
+			return filepath.SkipDir // skip irrelevant toplevel directories
 		}
-		crypto.TryMeasureData(crypto.ConfigData, grubcfg, path)
-		cfgs := ParseGrubCfg(string(grubcfg), basedir, 2)
-		bootconfigs = append(bootconfigs, cfgs...)
-	}
-	// Scan Grub Legacy configurations
-	for _, grubpath := range GrubLegacyPaths {
-		path := path.Join(basedir, grubpath)
-		log.Printf("Trying to read %s", path)
-		grubcfg, err := ioutil.ReadFile(path)
-		if err != nil {
-			log.Printf("cannot open %s: %v", path, err)
-			continue
+		if info.IsDir() {
+			log.Printf("Check %s", currentPath)
+			return nil // continue
 		}
-		crypto.TryMeasureData(crypto.ConfigData, grubcfg, path)
-		cfgs := ParseGrubCfg(string(grubcfg), basedir, 1)
-		bootconfigs = append(bootconfigs, cfgs...)
+		cfgname := info.Name()
+		if cfgname == "grub.cfg" || cfgname == "grub2.cfg" {
+			var ver grubVersion
+			if cfgname == "grub.cfg" {
+				ver = grubV1
+			} else if cfgname == "grub2.cfg" {
+				ver = grubV2
+			}
+			// try parsing
+			log.Printf("Trying to read %s", currentPath)
+			grubcfg, errRead := ioutil.ReadFile(currentPath)
+			if errRead != nil {
+				log.Printf("cannot open %s: %v", currentPath, errRead)
+				return nil // continue anyway
+			}
+			crypto.TryMeasureData(crypto.ConfigDataPCR, grubcfg, currentPath)
+			cfgs := ParseGrubCfg(ver, string(grubcfg), basedir) // TODO get root dir for cfgs out of grub.cfg instead of taking the curren basedir
+			bootconfigs = append(bootconfigs, cfgs...)
+		}
+		return nil // continue
+	})
+	if err != nil {
+		log.Printf("filepath.Walk error: %v \n", err)
 	}
 	return bootconfigs
 }

--- a/localboot/grub.go
+++ b/localboot/grub.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"io/ioutil"
 	"log"
 	"os"
@@ -101,7 +102,7 @@ func ParseGrubCfg(ver grubVersion, devices []storage.BlockDev, grubcfg string, b
 					if str1 == "--set=root" {
 						log.Printf("Kernel seems to be on an other partitioin then the grub.cfg file")
 						for _, str2 := range sline {
-							if len(str2) == 36 && string(str2[8]) == "-" && string(str2[13]) == "-" && string(str2[18]) == "-" && string(str2[23]) == "-" {
+							if isValidFsUUID(str2) {
 								kernelFsUUID := str2
 								log.Printf("fs-uuid: %s", kernelFsUUID)
 								partitions, err := storage.PartitionsByFsUUID(devices, kernelFsUUID)
@@ -160,6 +161,15 @@ func ParseGrubCfg(ver grubVersion, devices []storage.BlockDev, grubcfg string, b
 		bootconfigs = append(bootconfigs, *cfg)
 	}
 	return bootconfigs
+}
+
+func isValidFsUUID(uuid string) bool {
+	for _, h := range strings.Split(uuid, "-") {
+		if _, err := hex.DecodeString(h); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func unquote(ver grubVersion, text string) string {

--- a/localboot/grub.go
+++ b/localboot/grub.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/systemboot/systemboot/pkg/bootconfig"
+	"github.com/systemboot/systemboot/pkg/storage"
 )
 
 // List of directories where to recursively look for grub config files. The root dorectory
@@ -53,7 +54,7 @@ func isGrubSearchDir(dirname string) bool {
 // BootConfig structures, one for each menuentry, in the same order as they
 // appear in grub.cfg. All opened kernel and initrd files are relative to
 // basedir.
-func ParseGrubCfg(ver grubVersion, grubcfg string, basedir string) []bootconfig.BootConfig {
+func ParseGrubCfg(ver grubVersion, devices []storage.BlockDev, grubcfg string, basedir string) []bootconfig.BootConfig {
 	// This parser sucks. It's not even a parser, it just looks for lines
 	// starting with menuentry, linux or initrd.
 	// TODO use a parser, e.g. https://github.com/alecthomas/participle
@@ -61,6 +62,7 @@ func ParseGrubCfg(ver grubVersion, grubcfg string, basedir string) []bootconfig.
 		log.Printf("Warning: invalid GRUB version: %d", ver)
 		return nil
 	}
+	kernelBasedir := basedir
 	bootconfigs := make([]bootconfig.BootConfig, 0)
 	inMenuEntry := false
 	var cfg *bootconfig.BootConfig
@@ -92,6 +94,35 @@ func ParseGrubCfg(ver grubVersion, grubcfg string, basedir string) []bootconfig.
 			}
 			cfg.Name = name
 		} else if inMenuEntry {
+			// check if location of kernel is at an other partition
+			// see https://www.gnu.org/software/grub/manual/grub/html_node/search.html
+			if sline[0] == "search" {
+				for _, str1 := range sline {
+					if str1 == "--set=root" {
+						log.Printf("Kernel seems to be on an other partitioin then the grub.cfg file")
+						for _, str2 := range sline {
+							if len(str2) == 36 && string(str2[8]) == "-" && string(str2[13]) == "-" && string(str2[18]) == "-" && string(str2[23]) == "-" {
+								kernelFsUUID := str2
+								log.Printf("fs-uuid: %s", kernelFsUUID)
+								partitions, err := storage.PartitionsByFsUUID(devices, kernelFsUUID)
+								if err != nil {
+									log.Printf("Unexpected error while looking up fs uuid: %v", err) // PartitionsByFsUUID does not return an error for now
+								} else if len(partitions) == 0 {
+									log.Printf("WARNING: No partition found with filesystem uuid:'%s' to load kernel from!", kernelFsUUID) // TODO throw error ?
+									continue
+								}
+								if len(partitions) > 1 {
+									log.Printf("WARNING: more than one partition found with the given file. Using the first one")
+								}
+								dev := partitions[0]
+								kernelBasedir = path.Dir(kernelBasedir)
+								kernelBasedir = path.Join(kernelBasedir, dev.Name)
+								log.Printf("Kernel is on: %s", dev.Name)
+							}
+						}
+					}
+				}
+			}
 			// otherwise look for kernel and initramfs configuration
 			if len(sline) < 2 {
 				// surely not a valid linux or initrd directive, skip it
@@ -101,22 +132,22 @@ func ParseGrubCfg(ver grubVersion, grubcfg string, basedir string) []bootconfig.
 				kernel := sline[1]
 				cmdline := strings.Join(sline[2:], " ")
 				cmdline = unquote(ver, cmdline)
-				cfg.Kernel = path.Join(basedir, kernel)
+				cfg.Kernel = path.Join(kernelBasedir, kernel)
 				cfg.KernelArgs = cmdline
 			} else if sline[0] == "initrd" || sline[0] == "initrd16" || sline[0] == "initrdefi" {
 				initrd := sline[1]
-				cfg.Initramfs = path.Join(basedir, initrd)
+				cfg.Initramfs = path.Join(kernelBasedir, initrd)
 			} else if sline[0] == "multiboot" || sline[0] == "multiboot2" {
 				multiboot := sline[1]
 				cmdline := strings.Join(sline[2:], " ")
 				cmdline = unquote(ver, cmdline)
-				cfg.Multiboot = path.Join(basedir, multiboot)
+				cfg.Multiboot = path.Join(kernelBasedir, multiboot)
 				cfg.MultibootArgs = cmdline
 			} else if sline[0] == "module" || sline[0] == "module2" {
 				module := sline[1]
 				cmdline := strings.Join(sline[2:], " ")
 				cmdline = unquote(ver, cmdline)
-				module = path.Join(basedir, module)
+				module = path.Join(kernelBasedir, module)
 				if cmdline != "" {
 					module = module + " " + cmdline
 				}
@@ -148,7 +179,7 @@ func isMn(r rune) bool {
 
 // ScanGrubConfigs looks for grub2 and grub legacy config files in the known
 // locations and returns a list of boot configurations.
-func ScanGrubConfigs(basedir string) []bootconfig.BootConfig {
+func ScanGrubConfigs(devices []storage.BlockDev, basedir string) []bootconfig.BootConfig {
 	bootconfigs := make([]bootconfig.BootConfig, 0)
 	err := filepath.Walk(basedir, func(currentPath string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -177,6 +208,7 @@ func ScanGrubConfigs(basedir string) []bootconfig.BootConfig {
 			return nil
 		}
 		cfgname := info.Name()
+<<<<<<< HEAD
 		var ver grubVersion
 		switch cfgname {
 		case "grub.cfg":
@@ -190,6 +222,25 @@ func ScanGrubConfigs(basedir string) []bootconfig.BootConfig {
 		data, err := ioutil.ReadFile(currentPath)
 		if err != nil {
 			return err
+=======
+		if cfgname == "grub.cfg" || cfgname == "grub2.cfg" {
+			var ver grubVersion
+			if cfgname == "grub.cfg" {
+				ver = grubV1
+			} else if cfgname == "grub2.cfg" {
+				ver = grubV2
+			}
+			// try parsing
+			log.Printf("Trying to read %s", currentPath)
+			grubcfg, errRead := ioutil.ReadFile(currentPath)
+			if errRead != nil {
+				log.Printf("cannot open %s: %v", currentPath, errRead)
+				// continue anyway
+				return nil
+			}
+			cfgs := ParseGrubCfg(ver, devices, string(grubcfg), basedir)
+			bootconfigs = append(bootconfigs, cfgs...)
+>>>>>>> initial draft, support for vfat and ext4
 		}
 		cfgs := ParseGrubCfg(ver, string(data), basedir)
 		bootconfigs = append(bootconfigs, cfgs...)

--- a/localboot/grub.go
+++ b/localboot/grub.go
@@ -107,10 +107,8 @@ func ParseGrubCfg(ver grubVersion, devices []storage.BlockDev, grubcfg string, b
 							if isValidFsUUID(str2) {
 								kernelFsUUID := str2
 								log.Printf("fs-uuid: %s", kernelFsUUID)
-								partitions, err := storage.PartitionsByFsUUID(devices, kernelFsUUID)
-								if err != nil {
-									log.Printf("Unexpected error while looking up filesystem UUID: %v", err) // PartitionsByFsUUID does not return an error for now
-								} else if len(partitions) == 0 {
+								partitions := storage.PartitionsByFsUUID(devices, kernelFsUUID)
+								if len(partitions) == 0 {
 									log.Printf("WARNING: No partition found with filesystem UUID:'%s' to load kernel from!", kernelFsUUID) // TODO throw error ?
 									continue
 								}
@@ -158,6 +156,7 @@ func ParseGrubCfg(ver grubVersion, devices []storage.BlockDev, grubcfg string, b
 			}
 		}
 	}
+
 	// append last kernel config if it wasn't already
 	if inMenuEntry && cfg.IsValid() {
 		bootconfigs = append(bootconfigs, *cfg)

--- a/localboot/grub.go
+++ b/localboot/grub.go
@@ -208,7 +208,6 @@ func ScanGrubConfigs(devices []storage.BlockDev, basedir string) []bootconfig.Bo
 			return nil
 		}
 		cfgname := info.Name()
-<<<<<<< HEAD
 		var ver grubVersion
 		switch cfgname {
 		case "grub.cfg":
@@ -222,27 +221,8 @@ func ScanGrubConfigs(devices []storage.BlockDev, basedir string) []bootconfig.Bo
 		data, err := ioutil.ReadFile(currentPath)
 		if err != nil {
 			return err
-=======
-		if cfgname == "grub.cfg" || cfgname == "grub2.cfg" {
-			var ver grubVersion
-			if cfgname == "grub.cfg" {
-				ver = grubV1
-			} else if cfgname == "grub2.cfg" {
-				ver = grubV2
-			}
-			// try parsing
-			log.Printf("Trying to read %s", currentPath)
-			grubcfg, errRead := ioutil.ReadFile(currentPath)
-			if errRead != nil {
-				log.Printf("cannot open %s: %v", currentPath, errRead)
-				// continue anyway
-				return nil
-			}
-			cfgs := ParseGrubCfg(ver, devices, string(grubcfg), basedir)
-			bootconfigs = append(bootconfigs, cfgs...)
->>>>>>> initial draft, support for vfat and ext4
 		}
-		cfgs := ParseGrubCfg(ver, string(data), basedir)
+		cfgs := ParseGrubCfg(ver, devices, string(data), basedir)
 		bootconfigs = append(bootconfigs, cfgs...)
 		return nil
 	})

--- a/localboot/grub.go
+++ b/localboot/grub.go
@@ -84,6 +84,8 @@ func ParseGrubCfg(ver grubVersion, devices []storage.BlockDev, grubcfg string, b
 					// both kernel and initramfs
 					bootconfigs = append(bootconfigs, *cfg)
 				}
+				// reset kernelBaseDir
+				kernelBasedir = basedir
 			}
 			inMenuEntry = true
 			cfg = new(bootconfig.BootConfig)
@@ -107,13 +109,13 @@ func ParseGrubCfg(ver grubVersion, devices []storage.BlockDev, grubcfg string, b
 								log.Printf("fs-uuid: %s", kernelFsUUID)
 								partitions, err := storage.PartitionsByFsUUID(devices, kernelFsUUID)
 								if err != nil {
-									log.Printf("Unexpected error while looking up fs uuid: %v", err) // PartitionsByFsUUID does not return an error for now
+									log.Printf("Unexpected error while looking up filesystem UUID: %v", err) // PartitionsByFsUUID does not return an error for now
 								} else if len(partitions) == 0 {
-									log.Printf("WARNING: No partition found with filesystem uuid:'%s' to load kernel from!", kernelFsUUID) // TODO throw error ?
+									log.Printf("WARNING: No partition found with filesystem UUID:'%s' to load kernel from!", kernelFsUUID) // TODO throw error ?
 									continue
 								}
 								if len(partitions) > 1 {
-									log.Printf("WARNING: more than one partition found with the given file. Using the first one")
+									log.Printf("WARNING: more than one partition found with the given filesystem UUID. Using the first one")
 								}
 								dev := partitions[0]
 								kernelBasedir = path.Dir(kernelBasedir)

--- a/localboot/main.go
+++ b/localboot/main.go
@@ -115,7 +115,7 @@ func BootGrubMode(devices []storage.BlockDev, baseMountpoint string, guid string
 	// search for a valid grub config and extracts the boot configuration
 	bootconfigs := make([]bootconfig.BootConfig, 0)
 	for _, mountpoint := range mounted {
-		bootconfigs = append(bootconfigs, ScanGrubConfigs(mountpoint.Path)...)
+		bootconfigs = append(bootconfigs, ScanGrubConfigs(devices, mountpoint.Path)...)
 	}
 	if len(bootconfigs) == 0 {
 		return fmt.Errorf("No boot configuration found")

--- a/localboot/main.go
+++ b/localboot/main.go
@@ -130,17 +130,24 @@ func BootGrubMode(devices []storage.BlockDev, baseMountpoint string, guid string
 	if configIdx > -1 {
 		for n, cfg := range bootconfigs {
 			if configIdx == n {
+<<<<<<< HEAD
 				if dryrun {
 					debug("Dry-run mode: will not boot the found configuration")
 					debug("Boot configuration: %+v", cfg)
 					return nil
 				}
+=======
+>>>>>>> add config flag to selct bootconfig
 				if err := cfg.Boot(); err != nil {
 					log.Printf("Failed to boot kernel %s: %v", cfg.Kernel, err)
 				}
 			}
 		}
+<<<<<<< HEAD
 		log.Printf("Invalid arg -config %d: there are only %d bootconfigs available\n", configIdx, len(bootconfigs))
+=======
+		log.Printf("Invalig arg -config %d: there are Specify the bootconfigurless then %d bootconfigs available \n", configIdx, len(bootconfigs))
+>>>>>>> add config flag to selct bootconfig
 		return nil
 	}
 	if dryrun {

--- a/localboot/main.go
+++ b/localboot/main.go
@@ -130,24 +130,17 @@ func BootGrubMode(devices []storage.BlockDev, baseMountpoint string, guid string
 	if configIdx > -1 {
 		for n, cfg := range bootconfigs {
 			if configIdx == n {
-<<<<<<< HEAD
 				if dryrun {
 					debug("Dry-run mode: will not boot the found configuration")
 					debug("Boot configuration: %+v", cfg)
 					return nil
 				}
-=======
->>>>>>> add config flag to selct bootconfig
 				if err := cfg.Boot(); err != nil {
 					log.Printf("Failed to boot kernel %s: %v", cfg.Kernel, err)
 				}
 			}
 		}
-<<<<<<< HEAD
 		log.Printf("Invalid arg -config %d: there are only %d bootconfigs available\n", configIdx, len(bootconfigs))
-=======
-		log.Printf("Invalig arg -config %d: there are Specify the bootconfigurless then %d bootconfigs available \n", configIdx, len(bootconfigs))
->>>>>>> add config flag to selct bootconfig
 		return nil
 	}
 	if dryrun {

--- a/netboot/main.go
+++ b/netboot/main.go
@@ -222,7 +222,7 @@ func boot(ifname string, dhcp dhcpFunc) error {
 	if err != nil {
 		return fmt.Errorf("DHCP: cannot read boot file from the network: %v", err)
 	}
-	crypto.TryMeasureData(crypto.BootConfig, body, bootfile)
+	crypto.TryMeasureData(crypto.BootConfigPCR, body, bootfile)
 	u, err := url.Parse(bootfile)
 	if err != nil {
 		return fmt.Errorf("DHCP: cannot parse URL %s: %v", bootfile, err)

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -90,20 +90,6 @@ func (bc *BootConfig) Boot() error {
 			log.Printf("Error parsing multiboot header: %v", err)
 			return err
 		}
-		// export trampoline code from the current binary.
-		// p, err := os.Executable()
-		// if err != nil {
-		// 	return fmt.Errorf("Cannot find current executable path: %v", err)
-		// }
-		// trampoline, err := filepath.EvalSymlinks(p)
-		// if err != nil {
-		// 	return fmt.Errorf("Cannot eval symlinks for %v: %v", p, err)
-		// }
-		// load multiboot kernel and modules
-		// m := multiboot.New(bc.Multiboot, bc.MultibootArgs, trampoline, bc.Modules)
-		// if err := m.Load(true); err != nil {
-		// 	return fmt.Errorf("Load failed: %v", err)
-		// }
 		if err := multiboot.Load(true, bc.Multiboot, bc.MultibootArgs, bc.Modules); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -17,14 +17,14 @@ import (
 // characteristics from FIT but it's not compatible with it. It uses
 // JSON for interoperability.
 type BootConfig struct {
-	Name          string `json:"name,omitempty"`
-	Kernel        string `json:"kernel"`
-	Initramfs     string `json:"initramfs,omitempty"`
-	KernelArgs    string `json:"kernel_args,omitempty"`
-	DeviceTree    string `json:"devicetree,omitempty"`
-	Multiboot     string `json:"multiboot,omitempty"`
-	MultibootArgs string `json:"multiboot_args,omitempty"`
-	Modules       []string
+	Name          string   `json:"name,omitempty"`
+	Kernel        string   `json:"kernel"`
+	Initramfs     string   `json:"initramfs,omitempty"`
+	KernelArgs    string   `json:"kernel_args,omitempty"`
+	DeviceTree    string   `json:"devicetree,omitempty"`
+	Multiboot     string   `json:"multiboot_kernel,omitempty"`
+	MultibootArgs string   `json:"multiboot_args,omitempty"`
+	Modules       []string `json:"multiboot_modules, omitempty"`
 }
 
 // IsValid returns true if a BootConfig object has valid content, and false

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -24,7 +24,7 @@ type BootConfig struct {
 	DeviceTree    string   `json:"devicetree,omitempty"`
 	Multiboot     string   `json:"multiboot_kernel,omitempty"`
 	MultibootArgs string   `json:"multiboot_args,omitempty"`
-	Modules       []string `json:"multiboot_modules, omitempty"`
+	Modules       []string `json:"multiboot_modules,omitempty"`
 }
 
 // IsValid returns true if a BootConfig object has valid content, and false

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -3,34 +3,41 @@ package bootconfig
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/systemboot/systemboot/pkg/crypto"
 	"github.com/u-root/u-root/pkg/kexec"
+	"github.com/u-root/u-root/pkg/multiboot"
 )
 
 // BootConfig is a general-purpose boot configuration. It draws some
 // characteristics from FIT but it's not compatible with it. It uses
 // JSON for interoperability.
 type BootConfig struct {
-	Name       string `json:"name,omitempty"`
-	Kernel     string `json:"kernel"`
-	Initramfs  string `json:"initramfs,omitempty"`
-	KernelArgs string `json:"kernel_args,omitempty"`
-	DeviceTree string `json:"devicetree,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Kernel        string `json:"kernel"`
+	Initramfs     string `json:"initramfs,omitempty"`
+	KernelArgs    string `json:"kernel_args,omitempty"`
+	DeviceTree    string `json:"devicetree,omitempty"`
+	Multiboot     string `json:"multiboot,omitempty"`
+	MultibootArgs string `json:"multiboot_args,omitempty"`
+	Modules       []string
 }
 
 // IsValid returns true if a BootConfig object has valid content, and false
 // otherwise
 func (bc *BootConfig) IsValid() bool {
-	return bc.Kernel != ""
+	return (bc.Kernel != "" && bc.Multiboot == "") || (bc.Kernel == "" && bc.Multiboot != "")
 }
 
 // Boot tries to boot the kernel with optional initramfs and command line
 // options. If a device-tree is specified, that will be used too
 func (bc *BootConfig) Boot() error {
-	crypto.TryMeasureBootConfig(bc.Name, bc.Kernel, bc.Initramfs, bc.KernelArgs, bc.DeviceTree)
+	data := bc.Name + bc.Kernel + bc.Initramfs + bc.KernelArgs + bc.DeviceTree + bc.Multiboot + bc.MultibootArgs
+	crypto.TryMeasureData(crypto.BootConfigPCR, []byte(data), "bootconfig")
 
 	kernel, err := os.Open(bc.Kernel)
 	if err != nil {
@@ -42,30 +49,58 @@ func (bc *BootConfig) Boot() error {
 		if err != nil {
 			return err
 		}
-	}
-	defer func() {
-		// clean up
-		if kernel != nil {
-			if err := kernel.Close(); err != nil {
-				log.Printf("Error closing kernel file descriptor: %v", err)
+		var initramfs *os.File
+		if bc.Initramfs != "" {
+			initramfs, err = os.Open(bc.Initramfs)
+			if err != nil {
+				return err
 			}
 		}
-		if initramfs != nil {
-			if err := initramfs.Close(); err != nil {
-				log.Printf("Error closing initramfs file descriptor: %v", err)
+		defer func() {
+			// clean up
+			if kernel != nil {
+				if err := kernel.Close(); err != nil {
+					log.Printf("Error closing kernel file descriptor: %v", err)
+				}
 			}
+			if initramfs != nil {
+				if err := initramfs.Close(); err != nil {
+					log.Printf("Error closing initramfs file descriptor: %v", err)
+				}
+			}
+		}()
+		if err := kexec.FileLoad(kernel, initramfs, bc.KernelArgs); err != nil {
+			return err
 		}
-	}()
-	if err := kexec.FileLoad(kernel, initramfs, bc.KernelArgs); err != nil {
-		return err
+	} else if bc.Multiboot != "" {
+		// check multiboot header
+		if err := multiboot.Probe(bc.Multiboot); err != nil {
+			log.Printf("Error parsing multiboot header: %v", err)
+			return err
+		}
+		// export trampoline code from the current binary.
+		p, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("Cannot find current executable path: %v", err)
+		}
+		trampoline, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			return fmt.Errorf("Cannot eval symlinks for %v: %v", p, err)
+		}
+		// load multiboot kernel and modules
+		m := multiboot.New(bc.Multiboot, bc.MultibootArgs, trampoline, bc.Modules)
+		if err := m.Load(true); err != nil {
+			return fmt.Errorf("Load failed: %v", err)
+		}
+		if err := kexec.Load(m.EntryPoint, m.Segments(), 0); err != nil {
+			return fmt.Errorf("kexec.Load() error: %v", err)
+		}
 	}
-
 	err = kexec.Reboot()
 	if err == nil {
 		return errors.New("Unexpectedly returned from Reboot() without error. The system did not reboot")
 	}
 	return err
-
 }
 
 // NewBootConfig parses a boot configuration in JSON format and returns a

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/systemboot/systemboot/pkg/crypto"
 	"github.com/u-root/u-root/pkg/kexec"
@@ -73,20 +72,20 @@ func (bc *BootConfig) Boot() error {
 			return err
 		}
 		// export trampoline code from the current binary.
-		p, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("Cannot find current executable path: %v", err)
-		}
-		trampoline, err := filepath.EvalSymlinks(p)
-		if err != nil {
-			return fmt.Errorf("Cannot eval symlinks for %v: %v", p, err)
-		}
+		// p, err := os.Executable()
+		// if err != nil {
+		// 	return fmt.Errorf("Cannot find current executable path: %v", err)
+		// }
+		// trampoline, err := filepath.EvalSymlinks(p)
+		// if err != nil {
+		// 	return fmt.Errorf("Cannot eval symlinks for %v: %v", p, err)
+		// }
 		// load multiboot kernel and modules
-		m := multiboot.New(bc.Multiboot, bc.MultibootArgs, trampoline, bc.Modules)
-		if err := m.Load(true); err != nil {
-			return fmt.Errorf("Load failed: %v", err)
-		}
-		if err := kexec.Load(m.EntryPoint, m.Segments(), 0); err != nil {
+		// m := multiboot.New(bc.Multiboot, bc.MultibootArgs, trampoline, bc.Modules)
+		// if err := m.Load(true); err != nil {
+		// 	return fmt.Errorf("Load failed: %v", err)
+		// }
+		if err := multiboot.Load(true, bc.Multiboot, bc.MultibootArgs, bc.Modules); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}
 	}

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -38,14 +38,8 @@ func (bc *BootConfig) IsValid() bool {
 func (bc *BootConfig) Boot() error {
 	data := bc.Name + bc.Kernel + bc.Initramfs + bc.KernelArgs + bc.DeviceTree + bc.Multiboot + bc.MultibootArgs
 	crypto.TryMeasureData(crypto.BootConfigPCR, []byte(data), "bootconfig")
-
-	kernel, err := os.Open(bc.Kernel)
-	if err != nil {
-		return err
-	}
-	var initramfs *os.File
-	if bc.Initramfs != "" {
-		initramfs, err = os.Open(bc.Initramfs)
+	if bc.Kernel != "" {
+		kernel, err := os.Open(bc.Kernel)
 		if err != nil {
 			return err
 		}
@@ -96,7 +90,7 @@ func (bc *BootConfig) Boot() error {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}
 	}
-	err = kexec.Reboot()
+	err := kexec.Reboot()
 	if err == nil {
 		return errors.New("Unexpectedly returned from Reboot() without error. The system did not reboot")
 	}

--- a/pkg/bootconfig/zipconfig.go
+++ b/pkg/bootconfig/zipconfig.go
@@ -50,7 +50,7 @@ func FromZip(filename string, pubkeyfile *string) (*Manifest, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	crypto.TryMeasureData(crypto.Blob, data, filename)
+	crypto.TryMeasureData(crypto.BlobPCR, data, filename)
 	zipbytes := data
 	// Load the public key and, if a valid one is specified, match the
 	// signature. The signature is appended to the ZIP file, and can be present

--- a/pkg/booter/bootentry.go
+++ b/pkg/booter/bootentry.go
@@ -61,7 +61,7 @@ func GetBootEntries() []BootEntry {
 		// try the RW entries first
 		value, err := Get(key, false)
 		if err == nil {
-			crypto.TryMeasureData(crypto.NvramVars, value, key)
+			crypto.TryMeasureData(crypto.NvramVarsPCR, value, key)
 			bootEntries = append(bootEntries, BootEntry{Name: key, Config: value})
 			// WARNING WARNING WARNING this means that read-write boot entries
 			// have priority over read-only ones
@@ -70,7 +70,7 @@ func GetBootEntries() []BootEntry {
 		// try the RO entries then
 		value, err = Get(key, true)
 		if err == nil {
-			crypto.TryMeasureData(crypto.NvramVars, value, key)
+			crypto.TryMeasureData(crypto.NvramVarsPCR, value, key)
 			bootEntries = append(bootEntries, BootEntry{Name: key, Config: value})
 		}
 	}

--- a/pkg/crypto/measure.go
+++ b/pkg/crypto/measure.go
@@ -8,29 +8,34 @@ import (
 )
 
 const (
-	// Blob type in PCR 7
-	Blob uint32 = 7
-	// BootConfig type in PCR 8
-	BootConfig uint32 = 8
-	// ConfigData type in PCR 8
-	ConfigData uint32 = 8
-	// NvramVars type in PCR 9
-	NvramVars uint32 = 9
+	// BlobPCR type in PCR 7
+	BlobPCR uint32 = 7
+	// BootConfigPCR type in PCR 8
+	BootConfigPCR uint32 = 8
+	// ConfigDataPCR type in PCR 8
+	ConfigDataPCR uint32 = 8
+	// NvramVarsPCR type in PCR 9
+	NvramVarsPCR uint32 = 9
 )
 
 // TryMeasureBootConfig measures bootconfig contents
-func TryMeasureBootConfig(name, kernel, initramfs, kernelArgs, deviceTree string) {
+func TryMeasureBootConfig(name, kernel, initramfs, kernelArgs, deviceTree, multiboot, multibootArgs string, modules []string) {
 	TPMInterface, err := tpm.NewTPM()
 	if err != nil {
 		log.Printf("Cannot open TPM: %v", err)
 		return
 	}
-	TryMeasureData(BootConfig, []byte(name), name)
-	TryMeasureData(BootConfig, []byte(kernel), kernel)
-	TryMeasureData(BootConfig, []byte(initramfs), initramfs)
-	TryMeasureData(BootConfig, []byte(kernelArgs), kernelArgs)
-	TryMeasureData(BootConfig, []byte(deviceTree), deviceTree)
-	TryMeasureFiles(kernel, initramfs, deviceTree)
+	TryMeasureData(BootConfigPCR, []byte(name), name)
+	TryMeasureData(BootConfigPCR, []byte(kernel), kernel)
+	TryMeasureData(BootConfigPCR, []byte(initramfs), initramfs)
+	TryMeasureData(BootConfigPCR, []byte(kernelArgs), kernelArgs)
+	TryMeasureData(BootConfigPCR, []byte(deviceTree), deviceTree)
+	TryMeasureData(BootConfigPCR, []byte(multiboot), multiboot)
+	TryMeasureData(BootConfigPCR, []byte(multibootArgs), multibootArgs)
+	for i, module := range modules {
+		TryMeasureData(BootConfigPCR, []byte(module), module+string(i))
+	}
+	TryMeasureFiles(kernel, initramfs, deviceTree, multiboot)
 	TPMInterface.Close()
 }
 
@@ -59,7 +64,7 @@ func TryMeasureFiles(files ...string) {
 		if err != nil {
 			continue
 		}
-		TPMInterface.Measure(Blob, data)
+		TPMInterface.Measure(BlobPCR, data)
 	}
 	TPMInterface.Close()
 }

--- a/pkg/crypto/measure.go
+++ b/pkg/crypto/measure.go
@@ -18,27 +18,6 @@ const (
 	NvramVarsPCR uint32 = 9
 )
 
-// TryMeasureBootConfig measures bootconfig contents
-func TryMeasureBootConfig(name, kernel, initramfs, kernelArgs, deviceTree, multiboot, multibootArgs string, modules []string) {
-	TPMInterface, err := tpm.NewTPM()
-	if err != nil {
-		log.Printf("Cannot open TPM: %v", err)
-		return
-	}
-	TryMeasureData(BootConfigPCR, []byte(name), name)
-	TryMeasureData(BootConfigPCR, []byte(kernel), kernel)
-	TryMeasureData(BootConfigPCR, []byte(initramfs), initramfs)
-	TryMeasureData(BootConfigPCR, []byte(kernelArgs), kernelArgs)
-	TryMeasureData(BootConfigPCR, []byte(deviceTree), deviceTree)
-	TryMeasureData(BootConfigPCR, []byte(multiboot), multiboot)
-	TryMeasureData(BootConfigPCR, []byte(multibootArgs), multibootArgs)
-	for i, module := range modules {
-		TryMeasureData(BootConfigPCR, []byte(module), module+string(i))
-	}
-	TryMeasureFiles(kernel, initramfs, deviceTree, multiboot)
-	TPMInterface.Close()
-}
-
 // TryMeasureData measures a byte array with additional information
 func TryMeasureData(pcr uint32, data []byte, info string) {
 	TPMInterface, err := tpm.NewTPM()

--- a/pkg/storage/blockdev.go
+++ b/pkg/storage/blockdev.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -21,8 +22,9 @@ var (
 
 // BlockDev maps a device name to a BlockStat structure for a given block device
 type BlockDev struct {
-	Name string
-	Stat BlockStat
+	Name   string
+	Stat   BlockStat
+	FsUUID string
 }
 
 // Summary prints a multiline summary of the BlockDev object
@@ -165,9 +167,161 @@ func GetBlockStats() ([]BlockDev, error) {
 		if err != nil {
 			return nil, err
 		}
-		blockdevs = append(blockdevs, BlockDev{Name: devname, Stat: *bstat})
+		devpath := path.Join("/dev/", devname)
+		uuid := getUUID(devpath)
+		blockdevs = append(blockdevs, BlockDev{Name: devname, Stat: *bstat, FsUUID: uuid})
 	}
 	return blockdevs, nil
+}
+
+// func getUUID(devpath string) (fsuuid string, err error) {
+// 	output, err := exec.Command("blkid", devpath).Output()
+// 	if err != nil {
+// 		return fsuuid, err
+// 	} else {
+// 		fields := strings.Fields(string(output))
+// 		for _, field := range fields {
+// 			if strings.Contains(field, "UUID=") && !strings.Contains(field, "PARTUUID=") {
+// 				fsuuid = strings.Trim(field, `UUID"=`)
+// 			}
+// 		}
+// 		return fsuuid, nil
+// 	}
+// }
+
+func getUUID(devpath string) (fsuuid string) {
+
+	fsuuid = tryVFAT(devpath)
+	if fsuuid != "" {
+		log.Printf("###### FsUUIS in %s: %s", devpath, fsuuid)
+		return fsuuid
+	}
+	fsuuid = tryEXT4(devpath)
+	if fsuuid != "" {
+		log.Printf("###### FsUUIS in %s: %s", devpath, fsuuid)
+		return fsuuid
+	}
+	log.Printf("###### FsUUIS in %s: NONE", devpath)
+	return ""
+}
+
+//see https://www.nongnu.org/ext2-doc/ext2.html#DISK-ORGANISATION
+const (
+	EXT2SprblkOff       = 1024 // Offset of superblock in partition
+	EXT2SprblkSize      = 512  // Actually 1024 but most of the last byters are reserved
+	EXT2SprblkMagicOff  = 56   // Offset of magic number in suberblock
+	EXT2SprblkMagicSize = 2
+	EXT2SprblkMagic     = '\uEF53' // fixed value
+	EXT2SprblkUUIDOff   = 104      // Offset of UUID in superblock
+	EXT2SprblkUUIDSize  = 16
+)
+
+func tryEXT4(devname string) (uuid string) {
+	log.Printf("try ext4")
+	var off int64
+	b := make([]byte, 0)
+
+	file, err := os.Open(devname)
+	if err != nil {
+		log.Println(err)
+		return ""
+	}
+	defer file.Close()
+
+	fileinfo, err := file.Stat()
+	if err != nil {
+		log.Println(err)
+		return ""
+	}
+	fmt.Printf("%s %d\n", fileinfo.Name(), fileinfo.Size())
+
+	// magic number
+	b = make([]byte, EXT2SprblkMagicSize)
+	off = EXT2SprblkOff + EXT2SprblkMagicOff
+	_, err = file.ReadAt(b, off)
+	if err != nil {
+		log.Println(err)
+		return ""
+	}
+	magic := uint16(b[1])<<8 + uint16(b[0])
+	fmt.Printf("magic: 0x%x\n", magic)
+	if magic != EXT2SprblkMagic {
+		log.Printf("try ext4")
+		return ""
+	}
+
+	// filesystem UUID
+	b = make([]byte, EXT2SprblkUUIDSize)
+	off = EXT2SprblkOff + EXT2SprblkUUIDOff
+	_, err = file.ReadAt(b, off)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	uuid = fmt.Sprintf("%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8],
+		b[9], b[10], b[11], b[12], b[13], b[14], b[15])
+	fmt.Printf("UUID=%s\n", uuid)
+
+	return uuid
+}
+
+// see https://de.wikipedia.org/wiki/File_Allocation_Table#Aufbau
+const (
+	FAT32MagicOff  = 82 // Offset of magic number
+	FAT32MagicSize = 8
+	FAT32Magic     = "FAT32   " // fixed value
+	FAT32IDOff     = 67         // Offset of filesystem-ID / serielnumber. Treated as short filesystem UUID
+	FAT32IDSize    = 4
+)
+
+func tryVFAT(devname string) (uuid string) {
+	log.Printf("try vfat")
+	var off int64
+	b := make([]byte, 0)
+
+	file, err := os.Open(devname)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	defer file.Close()
+
+	fileinfo, err := file.Stat()
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	fmt.Printf("%s %d\n", fileinfo.Name(), fileinfo.Size())
+
+	// magic number
+	b = make([]byte, FAT32MagicSize)
+	off = 0 + FAT32MagicOff
+	_, err = file.ReadAt(b, off)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	magic := string(b)
+	fmt.Printf("magic: %s\n", magic)
+	if magic != FAT32Magic {
+		log.Printf("no vfat")
+		return ""
+	}
+
+	// filesystem UUID
+	b = make([]byte, FAT32IDSize)
+	off = 0 + FAT32IDOff
+	_, err = file.ReadAt(b, off)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	uuid = fmt.Sprintf("%02x%02x-%02x%02x",
+		b[3], b[2], b[1], b[0])
+	fmt.Printf("UUID=%s\n", uuid)
+
+	return uuid
 }
 
 // GetGPTTable tries to read a GPT table from the block device described by the
@@ -195,7 +349,7 @@ func FilterEFISystemPartitions(devices []BlockDev) ([]BlockDev, error) {
 }
 
 // PartitionsByGUID returns a list of BlockDev objects whose underlying
-// block device ahs the given GUID
+// block device has the given GUID
 func PartitionsByGUID(devices []BlockDev, guid string) ([]BlockDev, error) {
 	partitions := make([]BlockDev, 0)
 	for _, device := range devices {
@@ -211,6 +365,18 @@ func PartitionsByGUID(devices []BlockDev, guid string) ([]BlockDev, error) {
 			if part.Type.String() == guid {
 				partitions = append(partitions, device)
 			}
+		}
+	}
+	return partitions, nil
+}
+
+// PartitionsByFsUUID returns a list of BlockDev objects whose underlying
+// block device has a filesystem with the given UUID
+func PartitionsByFsUUID(devices []BlockDev, fsuuid string) ([]BlockDev, error) {
+	partitions := make([]BlockDev, 0)
+	for _, device := range devices {
+		if device.FsUUID == fsuuid {
+			partitions = append(partitions, device)
 		}
 	}
 	return partitions, nil

--- a/pkg/storage/blockdev.go
+++ b/pkg/storage/blockdev.go
@@ -357,14 +357,14 @@ func PartitionsByGUID(devices []BlockDev, guid string) ([]BlockDev, error) {
 
 // PartitionsByFsUUID returns a list of BlockDev objects whose underlying
 // block device has a filesystem with the given UUID
-func PartitionsByFsUUID(devices []BlockDev, fsuuid string) ([]BlockDev, error) {
+func PartitionsByFsUUID(devices []BlockDev, fsuuid string) []BlockDev {
 	partitions := make([]BlockDev, 0)
 	for _, device := range devices {
 		if device.FsUUID == fsuuid {
 			partitions = append(partitions, device)
 		}
 	}
-	return partitions, nil
+	return partitions
 }
 
 // GetMountpointByDevice gets the mountpoint by given

--- a/pkg/storage/blockdev.go
+++ b/pkg/storage/blockdev.go
@@ -174,21 +174,6 @@ func GetBlockStats() ([]BlockDev, error) {
 	return blockdevs, nil
 }
 
-// func getUUID(devpath string) (fsuuid string, err error) {
-// 	output, err := exec.Command("blkid", devpath).Output()
-// 	if err != nil {
-// 		return fsuuid, err
-// 	} else {
-// 		fields := strings.Fields(string(output))
-// 		for _, field := range fields {
-// 			if strings.Contains(field, "UUID=") && !strings.Contains(field, "PARTUUID=") {
-// 				fsuuid = strings.Trim(field, `UUID"=`)
-// 			}
-// 		}
-// 		return fsuuid, nil
-// 	}
-// }
-
 func getUUID(devpath string) (fsuuid string) {
 
 	fsuuid = tryVFAT(devpath)


### PR DESCRIPTION
Parse the set-root command from grub file, identify the partition wit the filsystem uuid given in that statatement, then sets the path of kernel, initramfs etc accordingly.
This is necessary since in EFI systems the grub.cfg usually resides on a different partition then the kernel.

For now recognision of ext4 and vfat filesystems is supported