### PR TITLE
Update to Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: false
 
 go:
-  - "1.11"
+  - "1.12"
 
 before_install:
   - go get -t -v ./...


### PR DESCRIPTION
Updating to Go 1.12. The underlying components (u-root, and the nclient4 from insomniacslk/dhcp) require Go 1.12, so we are bumping the version here too.