### PR TITLE
Scaffolding for fixmynetboot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ localboot/localboot
 localboot/.bb
 netboot/netboot
 netboot/.bb
+cmds/vpdbootmanager/vpdbootmanager
+cmds/fixmynetboot/fixmynetboot
 uinit/uinit
 uinit/.bb

--- a/cmds/fixmynetboot/colours.go
+++ b/cmds/fixmynetboot/colours.go
@@ -1,0 +1,43 @@
+package main
+
+import "fmt"
+
+// foreground colours
+const (
+	ColorBlack   = "\x1b[0;30m"
+	ColorRed     = "\x1b[0;31m"
+	ColorGreen   = "\x1b[0;32m"
+	ColorYellow  = "\x1b[0;33m"
+	ColorBlue    = "\x1b[0;34m"
+	ColorMagenta = "\x1b[0;35m"
+	ColorGrey    = "\x1b[0;36m"
+	ColorNone    = "\x1b[0m"
+)
+
+func colorize(col, f string, a ...interface{}) string {
+	return col + fmt.Sprintf(f, a...) + ColorNone
+}
+
+func red(format string, args ...interface{}) string {
+	return colorize(ColorRed, format, args...)
+}
+
+func green(format string, args ...interface{}) string {
+	return colorize(ColorGreen, format, args...)
+}
+
+func yellow(format string, args ...interface{}) string {
+	return colorize(ColorYellow, format, args...)
+}
+
+func blue(format string, args ...interface{}) string {
+	return colorize(ColorBlue, format, args...)
+}
+
+func magenta(format string, args ...interface{}) string {
+	return colorize(ColorMagenta, format, args...)
+}
+
+func grey(format string, args ...interface{}) string {
+	return colorize(ColorGrey, format, args...)
+}

--- a/cmds/fixmynetboot/dmesg.go
+++ b/cmds/fixmynetboot/dmesg.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+// shamelessly copied from u-root/cmds/dmesg
+const (
+	_SYSLOG_ACTION_READ_ALL = 3
+)
+
+func getDmesg() (string, error) {
+	level := uintptr(_SYSLOG_ACTION_READ_ALL)
+	b := make([]byte, 256*1024)
+	n, _, err := syscall.Syscall(syscall.SYS_SYSLOG, level, uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)))
+	if err != 0 {
+		return "", err
+	}
+	return string(b[:n]), nil
+}
+
+func grep(b, pattern string) []string {
+	lines := strings.Split(b, "\n")
+	ret := make([]string, 0)
+	for _, line := range lines {
+		if strings.Contains(line, pattern) {
+			ret = append(ret, line)
+		}
+	}
+	return ret
+}

--- a/cmds/fixmynetboot/interfaces.go
+++ b/cmds/fixmynetboot/interfaces.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"net"
+)
+
+func interfaceExists(ifname string) func() error {
+	return func() error {
+		_, err := net.InterfaceByName(ifname)
+		return err
+	}
+}
+
+func interfaceRemediate(ifname string) func() error {
+	return func() error {
+		// TODO implement driver checking logic
+		dmesg, err := getDmesg()
+		if err != nil {
+			return fmt.Errorf("cannot read dmesg to look for NIC driver information: %v", err)
+		}
+		lines := grep(dmesg, ifname)
+		if len(lines) == 0 {
+			return fmt.Errorf("no trace of %s in dmesg", ifname)
+		}
+		// TODO should this be returned as a string to the caller?
+		fmt.Printf("  found %d references to %s in dmesg\n", len(lines), ifname)
+		return nil
+	}
+}

--- a/cmds/fixmynetboot/interfaces.go
+++ b/cmds/fixmynetboot/interfaces.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+func interfaceExists(ifname string) Checker {
+	return func() error {
+		_, err := net.InterfaceByName(ifname)
+		return err
+	}
+}
+
+func interfaceHasLinkLocalAddress(ifname string) Checker {
+	return func() error {
+		iface, err := net.InterfaceByName(ifname)
+		if err != nil {
+			return err
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return err
+		}
+		for _, addr := range addrs {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok {
+				return errors.New("not a net.IPNet")
+			}
+			if ipnet.IP.IsLinkLocalUnicast() {
+				return nil
+			}
+		}
+		return fmt.Errorf("no link local addresses for interface %s", ifname)
+	}
+}
+
+func interfaceRemediate(ifname string) Remediator {
+	return func() error {
+		// TODO implement driver checking logic
+		dmesg, err := getDmesg()
+		if err != nil {
+			return fmt.Errorf("cannot read dmesg to look for NIC driver information: %v", err)
+		}
+		lines := grep(dmesg, ifname)
+		if len(lines) == 0 {
+			return fmt.Errorf("no trace of %s in dmesg", ifname)
+		}
+		// TODO should this be returned as a string to the caller?
+		fmt.Printf("  found %d references to %s in dmesg\n", len(lines), ifname)
+		return nil
+	}
+}

--- a/cmds/fixmynetboot/main.go
+++ b/cmds/fixmynetboot/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// fixmynetboot is a troubleshooting tool that can help you identify issues that
+// won't let your system boot over the network.
+
+// Check is a type that implements a netboot check
+type Check struct {
+	Name      string
+	Run       func() error
+	Remediate func() error
+}
+
+func main() {
+	checklist := []Check{
+		Check{"wlp2s0 exists", interfaceExists("wlp2s0"), nil},
+		Check{"eth0 exists", interfaceExists("eth0"), interfaceRemediate("eth0")},
+	}
+
+	for idx, check := range checklist {
+		fmt.Printf(green("#%d", idx+1)+" Running check '%s'.. ", check.Name)
+		if err := check.Run(); err != nil {
+			fmt.Println(red("failed: %v", err))
+			if check.Remediate != nil {
+				fmt.Println(yellow("  -> running remediation"))
+				if err := check.Remediate(); err != nil {
+					fmt.Printf(red("     Remediation for '%s' failed: %v\n", check.Name, err))
+					fmt.Println("Exiting")
+					os.Exit(1)
+				} else {
+					fmt.Printf("     Remediation for '%s' succeeded\n", check.Name)
+				}
+			} else {
+				fmt.Printf(yellow(" -> no remediation found for '%s', skipping\n", check.Name))
+			}
+		} else {
+			fmt.Println(green("OK"))
+		}
+	}
+}

--- a/cmds/fixmynetboot/main.go
+++ b/cmds/fixmynetboot/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// fixmynetboot is a troubleshooting tool that can help you identify issues that
+// won't let your system boot over the network.
+
+// Checker is the type of checking functions
+type Checker func() error
+
+// Remediator is the type of remediation functions
+type Remediator func() error
+
+// Check is a type that implements a netboot check
+type Check struct {
+	Name        string
+	Run         Checker
+	Remediate   Remediator
+	StopOnError bool
+}
+
+func main() {
+	checklist := []Check{
+		Check{"wlp2s0 exists", interfaceExists("wlp2s0"), nil, false},
+		Check{"eth0 exists", interfaceExists("eth0"), interfaceRemediate("eth0"), false},
+		Check{"eth0 has link-local", interfaceHasLinkLocalAddress("wlp2s0"), nil, false},
+	}
+
+	for idx, check := range checklist {
+		fmt.Printf(green("#%d", idx+1)+" Running check '%s'.. ", check.Name)
+		if err := check.Run(); err != nil {
+			fmt.Println(red("failed: %v", err))
+			if check.Remediate != nil {
+				fmt.Println(yellow("  -> running remediation"))
+				if err := check.Remediate(); err != nil {
+					fmt.Printf(red("     Remediation for '%s' failed: %v\n", check.Name, err))
+					if check.StopOnError {
+						fmt.Println("Exiting")
+						os.Exit(1)
+					}
+				} else {
+					fmt.Printf("     Remediation for '%s' succeeded\n", check.Name)
+				}
+			} else {
+				fmt.Printf(yellow(" -> no remediation found for '%s', skipping\n", check.Name))
+			}
+		} else {
+			fmt.Println(green("OK"))
+		}
+	}
+}


### PR DESCRIPTION

Example run:
```
$ go run .
#1 Running check 'wlp2s0 exists'.. OK
#2 Running check 'eth0 exists'.. failed: route ip+net: no such network interface
  -> running remediation
     Remediation for 'eth0 exists' failed: no trace of eth0 in dmesg
#3 Running check 'eth0 has link-local'.. OK
```

Signed-off-by: Andrea Barberio <insomniac@slackware.it>