### PR TITLE
[netboot] Call fixmynetboot if netboot fails

### DIFF
--- a/cmds/fixmynetboot/main.go
+++ b/cmds/fixmynetboot/main.go
@@ -1,22 +1,105 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
 	"github.com/systemboot/systemboot/pkg/checker"
 )
 
 // fixmynetboot is a troubleshooting tool that can help you identify issues that
 // won't let your system boot over the network.
+// NOTE: this is a DEMO tool. It's here only to show you how to write your own
+// checks and remediations. Don't use it in production.
 
-func main() {
+var emergencyShellBanner = `
+**************************************************************************
+** Interface checks failed, see the output above to debug the issue.     *
+** Entering the emergency shell, where you can run "fixmynetboot" again, *
+** or any other LinuxBoot command.                                       *
+**************************************************************************
+`
+
+var (
+	doEmergencyShell = flag.Bool("shell", false, "Run emergency shell if checks fail")
+)
+
+func checkInterface(ifname string) error {
 	checklist := []checker.Check{
-		checker.Check{"wlp2s0 exists", checker.InterfaceExists("wlp2s0"), nil, false},
-		checker.Check{"eth0 exists", checker.InterfaceExists("eth0"), checker.InterfaceRemediate("eth0"), false},
-		checker.Check{"eth0 link speed", checker.LinkSpeed("eth0", 100), nil, false},
-		checker.Check{"eth0 link autoneg", checker.LinkAutoneg("eth0", true), nil, false},
-		checker.Check{"eth0 has link-local", checker.InterfaceHasLinkLocalAddress("wlp2s0"), nil, false},
-		checker.Check{"eth0 has global addresses", checker.InterfaceHasGlobalAddresses("wlp2s0"), nil, false},
+		checker.Check{
+			Name:        fmt.Sprintf("%s exists", ifname),
+			Run:         checker.InterfaceExists(ifname),
+			Remediate:   checker.InterfaceRemediate(ifname),
+			StopOnError: true,
+		},
+		checker.Check{
+			Name:        fmt.Sprintf("%s link speed", ifname),
+			Run:         checker.LinkSpeed(ifname, 100),
+			Remediate:   nil,
+			StopOnError: false},
+		checker.Check{
+			Name:        fmt.Sprintf("%s link autoneg", ifname),
+			Run:         checker.LinkAutoneg(ifname, true),
+			Remediate:   nil,
+			StopOnError: false,
+		},
+		checker.Check{
+			Name:        fmt.Sprintf("%s has link-local", ifname),
+			Run:         checker.InterfaceHasLinkLocalAddress(ifname),
+			Remediate:   nil,
+			StopOnError: true,
+		},
+		checker.Check{
+			Name:        fmt.Sprintf("%s has global addresses", ifname),
+			Run:         checker.InterfaceHasGlobalAddresses("eth0"),
+			Remediate:   nil,
+			StopOnError: true,
+		},
 	}
 
-	checker.Run(checklist)
+	return checker.Run(checklist)
+}
 
+func getNonLoopbackInterfaces() ([]string, error) {
+	var interfaces []string
+	allInterfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	for _, iface := range allInterfaces {
+		if iface.Flags&net.FlagLoopback == 0 {
+			interfaces = append(interfaces, iface.Name)
+		}
+	}
+	return interfaces, nil
+}
+
+func main() {
+	flag.Parse()
+	var (
+		interfaces []string
+		err        error
+	)
+	ifname := flag.Arg(0)
+	if ifname == "" {
+		interfaces, err = getNonLoopbackInterfaces()
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		interfaces = []string{ifname}
+	}
+
+	for _, ifname := range interfaces {
+		if err := checkInterface(ifname); err != nil {
+			if !*doEmergencyShell {
+				log.Fatal(err)
+			}
+			if err := checker.EmergencyShell(emergencyShellBanner)(); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
 }

--- a/pkg/checker/commandexecutor.go
+++ b/pkg/checker/commandexecutor.go
@@ -1,18 +1,42 @@
 package checker
 
 import (
+	"log"
 	"os"
 	"os/exec"
 )
 
+// DefaultShell is used by EmergencyShell
+var DefaultShell = "elvish"
+
+func runCmd(prog string, args ...string) error {
+	cmd := exec.Command(prog, args...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
 // CommandExecutor returns a check that runs the provided command and arguments.
 func CommandExecutor(prog string, args ...string) Checker {
 	return func() error {
-		cmd := exec.Command(prog, args...)
-		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-		if err := cmd.Run(); err != nil {
-			return err
+		return runCmd(prog, args...)
+	}
+}
+
+// CommandExecutorRemediation is like CommandExecutor, but returns a Remediator.
+func CommandExecutorRemediation(prog string, args ...string) Remediator {
+	return func() error {
+		return runCmd(prog, args...)
+	}
+}
+
+// EmergencyShell is a remediation that prints the given banner, and then calls
+// an emergency shell.
+func EmergencyShell(banner string) Remediator {
+	return func() error {
+		log.Print(green("Running emergency shell: %s", DefaultShell))
+		if banner != "" {
+			log.Print(banner)
 		}
-		return nil
+		return CommandExecutorRemediation(DefaultShell)()
 	}
 }


### PR DESCRIPTION
fixmynetboot is now part of the netboot workflow. It is called
automatically if netboot fails, if speficied in the VPD variables,
or if `-fix` is passed.
    
Also corrected error handling logic in checker and restructured command
execution.

NOTE: this changes the default behaviour of `netboot`. To revert that, uinit should call `netboot -nofix`. However this should be safe, as `fixmynetboot` does non-destructive, fast checks.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>